### PR TITLE
Readme + Directory business + Cosmetics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,24 @@
-*.pt
-.DS_Store
-__pycache__
+# Training & data
 wandb
 runs
 datavol
+
+# Python
+__pycache__
+.ipynb_checkpoints
+
+# PyTorch
+*.pt
+
+# MacOS
+.DS_Store
+
+# Vim
+*.sw*
+
+# Python env
+venv
+env
+
+# CTags
+tags

--- a/README.md
+++ b/README.md
@@ -14,13 +14,33 @@ The script `tokenize_to_h5.py` can be used to prepare a dataset for training. Gi
 CC100 datasets can be downloaded [here](https://data.statmt.org/cc-100/). 
 
 ### Usage :
-To use `tokenize_to_h5.py`, first put a standalone `.txt` file inside a folder. Then, inside `tokenize_to_h5.py`, modify the following :
+To use `tokenize_to_h5.py`, first put a standalone `.txt` file inside a folder. Then, use `tokenize_to_h5.py` using the following arguments
 ``` 
-if __name__=='__main__':
-    txt_path = '' # Path to the .txt file to be tokenized
-    out_h5_folder = '' #  Folder that will contain the output .h5 file
-    tokenizer_folder = '' # Folder where the tokenizer will be saved
-    tokenizer_name = '' # Name of the tokenizer that will be saved
+usage: tokenize_to_h5.py [-h] --txt_path TXT_PATH
+
+        Script for preparing a .txt cc-100 dataset for training. Creates the
+        custom tokenizer, and tokenizes the text with it to generate the .h5
+        file for training.
+
+        To make one of those things independently (e.g., only make the custom
+        tokenizer), see modules/tok_utils
+        
+
+options:
+  -h, --help            show this help message and exit
+  --txt_path TXT_PATH, -t TXT_PATH
+                        
+                                The input file to be tokenized. This script will save the following
+                                items:
+                                1) given the path of a source plain text file, a folder of the same
+                                name as the containing folder of txt_path, with '_h5' appended at the
+                                end, as well as raw Pytorch tensors and a backup. Example:
+                                    -t code_dataset/input.txt -> code_dataset_h5/code_dataset.h5
+                                                                 code_dataset_backup/input.txt
+                                                                 code_dataset/input_tokenized.pt
+                                2) a tokenizer in modules/tokenizers called after the folder containing
+                                the txt dataset. Example:
+                                    -t code_dataset/input.txt -> modules/tokenizers/code_dataset_tokenizer/
 ```
 
 Then run the script. NOTE : tokenization of large .txt files (>100GB) might take a while (1,2 days). This script is NOT designed to pick up where it left off if it crashes. For bigger datasets, consider making a script (include `from modules.tok_utils import *`), and run, subsequently :

--- a/README.md
+++ b/README.md
@@ -34,19 +34,18 @@ options:
                                 items:
                                 1) given the path of a source plain text file, a folder of the same
                                 name as the containing folder of txt_path, with '_h5' appended at the
-                                end, as well as raw Pytorch tensors and a backup. Example:
-                                    -t code_dataset/input.txt -> code_dataset_h5/code_dataset.h5
-                                                                 code_dataset_backup/input.txt
-                                                                 code_dataset/input_tokenized.pt
+                                end, as well as raw Pytorch tensors. Example:
+                                    -t my_dataset/input.txt -> my_dataset_h5/input.h5
+                                                               my_dataset_pt/input_tokenized.pt
                                 2) a tokenizer in modules/tokenizers called after the folder containing
                                 the txt dataset. Example:
-                                    -t code_dataset/input.txt -> modules/tokenizers/code_dataset_tokenizer/
+                                    -t my_dataset/input.txt -> modules/tokenizers/code_dataset_tokenizer/
 ```
 
 Then run the script. NOTE : tokenization of large .txt files (>100GB) might take a while (1,2 days). This script is NOT designed to pick up where it left off if it crashes. For bigger datasets, consider making a script (include `from modules.tok_utils import *`), and run, subsequently :
     - `create_tokenizer(txt_path, tokenizer_folder,tokenizer_name=tokenizer_name)` : Will train the BPE tokenizer on the given .txt file, and save it in <tokenizer_folder>/<tokenizer_name>
     - `tokenize_folder(os.path.dirname(txt_path), os.path.join(tokenizer_folder,tokenizer_name))` : Will tokenize the text file, splitting it into subfiles if necessary for memory reasons. Saved the tokenized tensors as `.pt`. If it crashes mid-way, can be restarted, and will pickup from last checkpoint
-    - `make_h5(os.path.dirname(txt_path), out_h5_folder,toki)` : Will convert a folder containing `.pt` files into a single `.h5` dataset, ready for training.
+    - `make_h5(os.path.dirname(txt_path), os.path.splitext(os.path.basename(txt_path))[0], out_h5_folder,toki)` : Will convert a folder containing `.pt` files into a single `.h5` dataset, ready for training.
 
 For more informations on these functions, look at docstring comments in `modules/tok_utils`
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,44 @@
-# BackPerplexity
-Investigate perplexity of LLM's when trained backward vs forward
+<div align="center">
 
-Code for experimenting on the presence of an Arrow of Time in code.
+<h2>Arrows of Time for Large Language Models</h2> 
+
+  <a href='https://arxiv.org/abs/2401.17505'><img src='https://img.shields.io/badge/ArXiv-2401.17505-red'></a> 
+
+  <div>
+      <a href='https://scholar.google.com/citations?user=4o52I2oAAAAJ&hl=en' target='_blank'>Vassilis Papadopoulos<sup>* 1 2</sup> </a>&emsp;
+      <a href='https://jeremiewenger.com/' target='_blank'>Jérémie Wenger<sup>3</a>&emsp;
+      <a href='https://scholar.google.com/citations?user=p9B6eWEAAAAJ&hl=en'_blank'>Clément Hongler<sup>* 2</sup></a>&emsp;
+  </div>
+  <br>
+  <div style='font-size: 8pt'>
+      <sup>1</sup> FSL/Institute of Physics, EPFL, Switzerland &emsp; <sup>2</sup> CSFT/Institute of Mathematics, EPFL, Switzerland &emsp; <sup>3</sup> Department of Computing, Goldsmiths/UoL, London, UK
+  </div>
+  <div style='font-size: 8pt'>Correspondence to: Clément Hongler, clement.hongler©epfl.ch</div>
+  <div style='font-size: 8pt'><sup>*</sup> equal contributions</div>
+
+  <br>
+
+  <h3>Abstract</h3>
+
+  <div style='text-align:justify'>We study the probabilistic modeling performed by Autoregressive Large Language Models (LLMs) through the angle of time directionality, addressing a question first raised in (Shannon, 1951). For large enough models, we empirically find a time asymmetry in their ability to learn natural lan- guage: a difference in the average log-perplexity when trying to predict the next token versus when trying to predict the previous one. This difference is at the same time subtle and very consistent across various modalities (language, model size, training time, ...). Theoretically, this is surprising: from an information-theoretic point of view, there should be no such difference. We provide a theoretical framework to explain how such an asymmetry can appear from sparsity and compu- tational complexity considerations, and outline a number of perspectives opened by our results.</div>
+
+  <br>
+
+  <figure>
+    <img src='pics/en-fr.train-valid.combined_with_inset.svg'>
+    <legend>English vs French validation losses (French training losses in the zoom-in, early loss values cropped for readability). </legend>
+  </figure>
+
+</div>
+
+
+
+---
+
+## Installation
 
 Install requirements using `pip install -r requirements.txt`.
+
 NOTE : On Windows, doing this might install torch without CUDA support. If this is the case, first install pytorch CUDA following instruction on the official [website](https://pytorch.org/), then run `pip install -r requirements.txt`.
 
 Read the following section to learn how to reproduce experiments.
@@ -14,6 +49,7 @@ The script `tokenize_to_h5.py` can be used to prepare a dataset for training. Gi
 CC100 datasets can be downloaded [here](https://data.statmt.org/cc-100/). 
 
 ### Usage :
+
 To use `tokenize_to_h5.py`, first put a standalone `.txt` file inside a folder. Then, use `tokenize_to_h5.py` using the following arguments
 ``` 
 usage: tokenize_to_h5.py [-h] --txt_path TXT_PATH
@@ -42,19 +78,22 @@ options:
                                     -t my_dataset/input.txt -> modules/tokenizers/code_dataset_tokenizer/
 ```
 
-Then run the script. NOTE : tokenization of large .txt files (>100GB) might take a while (1,2 days). This script is NOT designed to pick up where it left off if it crashes. For bigger datasets, consider making a script (include `from modules.tok_utils import *`), and run, subsequently :
-    - `create_tokenizer(txt_path, tokenizer_folder,tokenizer_name=tokenizer_name)` : Will train the BPE tokenizer on the given .txt file, and save it in <tokenizer_folder>/<tokenizer_name>
-    - `tokenize_folder(os.path.dirname(txt_path), os.path.join(tokenizer_folder,tokenizer_name))` : Will tokenize the text file, splitting it into subfiles if necessary for memory reasons. Saved the tokenized tensors as `.pt`. If it crashes mid-way, can be restarted, and will pickup from last checkpoint
-    - `make_h5(os.path.dirname(txt_path), os.path.splitext(os.path.basename(txt_path))[0], out_h5_folder,toki)` : Will convert a folder containing `.pt` files into a single `.h5` dataset, ready for training.
+Then run the script.
+
+NOTE : tokenization of large .txt files (>100GB) might take a while (1,2 days). This script is NOT designed to pick up where it left off if it crashes. For bigger datasets, consider making a script (include `from modules.tok_utils import *`), and run, subsequently :  
+- `create_tokenizer(txt_path, tokenizer_folder,tokenizer_name=tokenizer_name)` : Will train the BPE tokenizer on the given .txt file, and save it in <tokenizer_folder>/<tokenizer_name>  
+- `tokenize_folder(os.path.dirname(txt_path), os.path.join(tokenizer_folder,tokenizer_name))` : Will tokenize the text file, splitting it into subfiles if necessary for memory reasons. Saved the tokenized tensors as `.pt`. If it crashes mid-way, can be restarted, and will pickup from last checkpoint  
+- `make_h5(os.path.dirname(txt_path), os.path.splitext(os.path.basename(txt_path))[0], out_h5_folder,toki)` : Will convert a folder containing `.pt` files into a single `.h5` dataset, ready for training.
 
 For more informations on these functions, look at docstring comments in `modules/tok_utils`
 
 ### Tokenizer class
+
 The tokenizer class we use throughout the project is defined in `modules/tokenizer.py`. It is a wrapper on top of the Huggingface tokenizer.
 
 Here is all you need to know to use the tokenizers :
 
-```
+```python
 from modules import tokenizer
 
 toki = tokenizer.get_tokenizer(m_path='modules/tokenizers/en_tokenizer') # Load a saved tokenizer by specifying saved folder
@@ -76,7 +115,8 @@ For training, 4 scripts are provided. All are designed to train models on the da
 
 
 For all 4 scripts, usage is as follows :
-```usage: train_xxx.py [-h] [-d DEVICE] [-t TOKENIZER_PATH] [-p PROJECT_NAME] [-s] file_location
+```
+usage: train_xxx.py [-h] [-d DEVICE] [-t TOKENIZER_PATH] [-p PROJECT_NAME] [-s] file_location
 
 Starts training of Predictor model given a JSON config file.
 
@@ -96,44 +136,46 @@ options:
   ```
 
 Example :
-`python train_script.py path/to/config.json -d cuda:0 -t path/to/tokenizer -p MyTrainingProject -s`
+```bash
+python train_script.py path/to/config.json -d cuda:0 -t path/to/tokenizer -p MyTrainingProject -s
+```
 
 ### JSON config file
 To run the training script, we need to provide it with a path to the JSON config file. Their format slightly depends if training a GPT, GRU or LSTM model. In a nutshell, they contain all the necessary hyperparameters for a training run.
 
 Here is a description of each entry : 
 
-```
+```json
 {
-    "model_params": { # Model parameters
-        "vocab_size": 50257, # Vocabulary size
-        "n_layers": 12, # Number of Transformer Blocks
-        "n_heads": 12, # Number of attention heads
-        "embed_dim": 768, # Number of hidden/embedding dimensions
-        "attn_length": 256, # Attention Length
-        "mlp_ratio": 4.0, # MLP ratio
-        "dropout": 0.1, # Dropout inside tranformer blocks
-        "embd_dropout": null # Dropout for the token embeddings. Defaults to 0.
+    "model_params": {                              # Model parameters
+        "vocab_size": 50257,                       # Vocabulary size
+        "n_layers": 12,                            # Number of Transformer Blocks
+        "n_heads": 12,                             # Number of attention heads
+        "embed_dim": 768,                          # Number of hidden/embedding dimensions
+        "attn_length": 256,                        # Attention Length
+        "mlp_ratio": 4.0,                          # MLP ratio
+        "dropout": 0.1,                            # Dropout inside tranformer blocks
+        "embd_dropout": null                       # Dropout for the token embeddings. Defaults to 0.
     },
     "training_params": { 
-        "dataset_folder": "english/english.h5", # Location of .h5 dataset to train on
-        "batch_size": 180, # Batch size
-        "aggregate": 1, # Number of times to aggregate gradients before gradient step. (effective batch_size = aggregate*batch_size)
-        "backwards": false, # Whether to train in the backwards direction
-        "steps_to_train": null, # Number of gradient steps to train. Defaults to one epoch of the dataset.
-        "save_every": 3000, # Number of steps between each save of the training state.
-        "backup_every": 15000, # Number of steps between a backup of the training state.
-        "step_log": 400, # Number of steps between each log of training loss in wandb
-        "valid_steps": 1000, # Number of batches seen during one validation.
-        "state_save_loc": "datavol/vassilis/runs" # folder in which to save the training state.
+        "dataset_folder": "english/english.h5",    # Location of .h5 dataset to train on
+        "batch_size": 180,                         # Batch size
+        "aggregate": 1,                            # Number of times to aggregate gradients before gradient step. (effective batch_size = aggregate*batch_size)
+        "backwards": false,                        # Whether to train in the backwards direction
+        "steps_to_train": null,                    # Number of gradient steps to train. Defaults to one epoch of the dataset.
+        "save_every": 3000,                        # Number of steps between each save of the training state.
+        "backup_every": 15000,                     # Number of steps between a backup of the training state.
+        "step_log": 400,                           # Number of steps between each log of training loss in wandb
+        "valid_steps": 1000,                       # Number of batches seen during one validation.
+        "state_save_loc": "datavol/vassilis/runs"  # folder in which to save the training state.
     },
     "optim_params": {
-        "lr": 0.0001, # Base learning rate
-        "warmup_steps": 4000, # Number of batches until learning rate warms up
-        "oscil_steps": 300000, # Number of steps between warm restarts
-        "lr_shrink": 0.85, # Shrinking factor of lr between warm restarts
-        "lr_init": 1e-07, # Initial learning rate, for warmup
-        "lr_min": 1e-06 # Minimum learning rate reached during cosine annealing.
+        "lr": 0.0001,                              # Base learning rate
+        "warmup_steps": 4000,                      # Number of batches until learning rate warms up
+        "oscil_steps": 300000,                     # Number of steps between warm restarts
+        "lr_shrink": 0.85,                         # Shrinking factor of lr between warm restarts
+        "lr_init": 1e-07,                          # Initial learning rate, for warmup
+        "lr_min": 1e-06                            # Minimum learning rate reached during cosine annealing.
     }
 }
 ```

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,4 +1,20 @@
-from .models import *
-from .datasets import *
-from .tokenizer import get_tokenizer, tokenize_txt_file, Tokenizer
-from .tok_utils import create_custom_tokenizer, tokenize_folder, make_h5
+from .models import MinGPT as MinGPT
+from .models import MinGPT_Trainer as MinGPT_Trainer
+
+from .models import MinGRU as MinGRU
+from .models import MinLSTM as MinLSTM
+from .models import MinGRU_Trainer as MinGRU_Trainer
+
+from .models import load_model as load_model
+from .models import load_trainer as load_trainer
+
+from .datasets import TokenTexth5 as TokenTexth5
+from .datasets import TokenTextBOS as TokenTextBOS
+
+from .tokenizer import Tokenizer as Tokenizer
+from .tokenizer import get_tokenizer as get_tokenizer
+from .tokenizer import tokenize_txt_file as tokenize_txt_file
+
+from .tok_utils import make_h5 as make_h5
+from .tok_utils import tokenize_folder as tokenize_folder
+from .tok_utils import create_custom_tokenizer as create_custom_tokenizer

--- a/modules/datasets/TokenText.py
+++ b/modules/datasets/TokenText.py
@@ -1,6 +1,9 @@
-from torch.utils.data import Dataset
-import torch,os, h5py
+import os
+import h5py
 import numpy as np
+
+import torch
+from torch.utils.data import Dataset
 
 
 class TokenTexth5(Dataset):
@@ -21,7 +24,7 @@ class TokenTexth5(Dataset):
 
         self.backwards = backwards
 
-        
+
         if(stride is None):
             self.stride=self.attn_length//2
         else :
@@ -29,14 +32,14 @@ class TokenTexth5(Dataset):
 
         if(not os.path.isfile(self.h5_file)):
             raise ValueError(f'File/Folder {self.h5_file} not found')
-        
+
         self.h5_file = h5py.File(self.h5_file, 'r')
         self.text_tensor = self.h5_file['tokens']
 
 
         self.num_tokens = len(self.text_tensor)
         self.length = (self.num_tokens-self.attn_length-1)//(self.stride) # -1 because we need to have a target for each input
-    
+
         print(f'Dataset contains {self.num_tokens/1e6:.2f}M tokens, resulting in {self.length//1000}k examples.')
 
     def __len__(self):
@@ -80,7 +83,7 @@ class TokenTextBOS(Dataset):
         # attn_length is actually the length of the text that is produced. Adding the BOS, we get sentences of length attn_length+1
         self.backwards = backwards
 
-        
+
         if(stride is None):
             self.stride=self.attn_length//2
         else :
@@ -88,7 +91,7 @@ class TokenTextBOS(Dataset):
 
         if(not os.path.isfile(self.h5_file)):
             raise ValueError(f'File/Folder {self.h5_file} not found')
-        
+
         self.h5_file = h5py.File(self.h5_file, 'r')
         self.text_tensor = self.h5_file['tokens']
 
@@ -125,4 +128,4 @@ class TokenTextBOS(Dataset):
             tens : tensor of shape (attn_length)
         """
         return torch.cat([torch.tensor([0],dtype=torch.long),tens],dim=0) # (attn_length+1)
-    
+

--- a/modules/datasets/__init__.py
+++ b/modules/datasets/__init__.py
@@ -1,1 +1,2 @@
-from .TokenText import *
+from .TokenText import TokenTexth5 as TokenTexth5
+from .TokenText import TokenTextBOS as TokenTextBOS

--- a/modules/models/__init__.py
+++ b/modules/models/__init__.py
@@ -1,3 +1,9 @@
-from .mingpt import *
-from .gru import *
-from .load_model import load_model, load_trainer
+from .mingpt import MinGPT as MinGPT
+from .mingpt import MinGPT_Trainer as MinGPT_Trainer
+
+from .gru import MinGRU as MinGRU
+from .gru import MinLSTM as MinLSTM
+from .gru import MinGRU_Trainer as MinGRU_Trainer
+
+from .load_model import load_model as load_model
+from .load_model import load_trainer as load_trainer

--- a/modules/models/gru/MinGRU.py
+++ b/modules/models/gru/MinGRU.py
@@ -1,9 +1,15 @@
 """
 Full definition of a GPT Language Model.
 """
-import math, torch, torch.nn as nn
+
+import math
+
+import torch
+import torch.nn as nn
 from torch.nn import functional as F
-from torchenhanced import ConfigModule,DevModule
+
+from torchenhanced import DevModule
+from torchenhanced import ConfigModule
 
 
 class MinGRU(ConfigModule):

--- a/modules/models/gru/MinGRU_Trainer.py
+++ b/modules/models/gru/MinGRU_Trainer.py
@@ -1,9 +1,15 @@
-import torch, torch.nn.functional as F
+import wandb
+import random
+
+import torch
+import torch.nn.functional as F
+
 from torch.optim.lr_scheduler import _LRScheduler
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
-import wandb, random
+
 from torchenhanced import Trainer
+
 from .MinGRU import MinGRU
 from ...datasets import TokenText
 from ...tokenizer import Tokenizer

--- a/modules/models/gru/MinGRU_Trainer.py
+++ b/modules/models/gru/MinGRU_Trainer.py
@@ -16,8 +16,8 @@ from ...tokenizer import Tokenizer
 
 
 class MinGRU_Trainer(Trainer):
-    def __init__(self, model: MinGRU, train_dataset: TokenText, valid_dataset : TokenText, backwards : bool=True, 
-                 detokenizer :Tokenizer=None, optim: Optimizer = None, scheduler: _LRScheduler = None, 
+    def __init__(self, model: MinGRU, train_dataset: TokenText, valid_dataset : TokenText, backwards : bool=True,
+                 detokenizer :Tokenizer=None, optim: Optimizer = None, scheduler: _LRScheduler = None,
                  state_save_loc=None, device: str = 'cpu',parallel=None, run_name: str = None, project_name: str = None,
                  run_config: dict ={}):
         super().__init__(model, optim, scheduler, state_save_loc=state_save_loc, device=device, parallel=parallel,
@@ -46,10 +46,10 @@ class MinGRU_Trainer(Trainer):
     def process_batch(self, batch_data):
         # Check if correct, but should be :
         loss = self.compute_loss(batch_data)
-        
+
         if(self.do_batch_log) :
             wandb.log({'lr' : self.scheduler.get_last_lr()[0]},commit=False)
-    
+
         return loss
 
     def compute_loss(self, batch_data):
@@ -73,7 +73,7 @@ class MinGRU_Trainer(Trainer):
         loss = self.compute_loss(batch_data)
 
         return loss
-        
+
 
     def valid_log(self):
         #To be implemented when doing validation
@@ -87,7 +87,7 @@ class MinGRU_Trainer(Trainer):
         else :
             phrase_out=self.detokenizer.detokenize(phrase_out)
 
-        self.text_table.add_data(f"{self.steps_done/1000:.1f}k",phrase_out) 
+        self.text_table.add_data(f"{self.steps_done/1000:.1f}k",phrase_out)
         # Trick to be able to update table on the fly... Fucking wandb
         new_table = wandb.Table(
         columns=self.text_table.columns, data=self.text_table.data

--- a/modules/models/gru/__init__.py
+++ b/modules/models/gru/__init__.py
@@ -1,2 +1,4 @@
-from .MinGRU import MinGRU, MinLSTM
-from .MinGRU_Trainer import MinGRU_Trainer
+from .MinGRU import MinGRU as MinGRU
+from .MinGRU import MinLSTM as MinLSTM
+
+from .MinGRU_Trainer import MinGRU_Trainer as MinGRU_Trainer

--- a/modules/models/load_model.py
+++ b/modules/models/load_model.py
@@ -7,10 +7,10 @@ from .mingpt import MinGPT_Trainer
 
 def load_model(model_name:str, model_config:dict):
     """
-        Loads and return model.
+    Loads and return model.
 
-        Args:
-        model_name : name of the model to load. 'gru','lstm' or 'gpt'
+    Args:
+        model_name: name of the model to load. 'gru','lstm' or 'gpt'
     """
     model_dict= {'gru':MinGRU,'lstm':MinLSTM,'gpt':MinGPT}
     assert model_name.lower() in ['gru','lstm','gpt'], 'Model name should be one of "gru","lstm" or "gpt"'
@@ -19,11 +19,11 @@ def load_model(model_name:str, model_config:dict):
 
 def load_trainer(model_name: str, trainer_config:dict):
     """
-        Loads and return trainer.
+    Loads and return trainer.
 
-        Args:
-        model_name : name of the model to load. 'gru','lstm' or 'gpt'
-        trainer_config : dict of parameters to the trainer
+    Args:
+        model_name: name of the model to load. 'gru','lstm' or 'gpt'
+        trainer_config: dict of parameters to the trainer
     """
 
     trainer_dict = {'gru':MinGRU_Trainer,'lstm':MinGRU_Trainer,'gpt':MinGPT_Trainer}

--- a/modules/models/load_model.py
+++ b/modules/models/load_model.py
@@ -1,5 +1,9 @@
-from .gru import MinGRU,MinLSTM, MinGRU_Trainer
-from .mingpt import MinGPT, MinGPT_Trainer
+from .gru import MinGRU
+from .gru import MinLSTM
+from .gru import MinGRU_Trainer
+
+from .mingpt import MinGPT
+from .mingpt import MinGPT_Trainer
 
 def load_model(model_name:str, model_config:dict):
     """

--- a/modules/models/mingpt/MinGPT.py
+++ b/modules/models/mingpt/MinGPT.py
@@ -14,38 +14,41 @@ from torchenhanced import ConfigModule
 
 
 class MinGPT(ConfigModule):
-    """ 
-        GPT Language Model.
+    """
+    GPT Language Model.
 
-        For reference, here are some standard parameters
-        # GPT-1
-        n_layer=12, n_head=12, n_embd=768  # 117M params
-        # GPT-2 configs
-        'gpt2':         n_layer=12, n_head=12, n_embd=768,  # 124M params
-        'gpt2-medium':  n_layer=24, n_head=16, n_embd=1024, # 350M params
-        'gpt2-large':   n_layer=36, n_head=20, n_embd=1280, # 774M params
-        'gpt2-xl':      n_layer=48, n_head=25, n_embd=1600, # 1558M params
-        # Gophers
-        'gopher-44m':   n_layer=8, n_head=16, n_embd=512,
-        'gpt-mini':     n_layer=6, n_head=6, n_embd=192,
-        'gpt-micro':    n_layer=4, n_head=4, n_embd=128,
-        'gpt-nano':     n_layer=3, n_head=3, n_embd=48,
+    For reference, here are some standard parameters
+
+    # GPT-1
+    n_layer=12, n_head=12, n_embd=768  # 117M params
+
+    # GPT-2 configs
+    'gpt2':         n_layer=12, n_head=12, n_embd=768,  # 124M params
+    'gpt2-medium':  n_layer=24, n_head=16, n_embd=1024, # 350M params
+    'gpt2-large':   n_layer=36, n_head=20, n_embd=1280, # 774M params
+    'gpt2-xl':      n_layer=48, n_head=25, n_embd=1600, # 1558M params
+
+    # Gophers
+    'gopher-44m':   n_layer=8, n_head=16, n_embd=512,
+    'gpt-mini':     n_layer=6, n_head=6, n_embd=192,
+    'gpt-micro':    n_layer=4, n_head=4, n_embd=128,
+    'gpt-nano':     n_layer=3, n_head=3, n_embd=48,
     """
 
-    def __init__(self, vocab_size:int,n_layers:int,embed_dim :int, n_heads:int,attn_length:int, 
+    def __init__(self, vocab_size:int,n_layers:int,embed_dim :int, n_heads:int,attn_length:int,
                  mlp_ratio:float=4,dropout:float=0.1, embd_dropout:float=None):
         """
-            Args :
-                vocab_size : number of tokens in the vocabulary
-                n_layer : number of transformer layers
-                embed_dim : number of embedding dimensions
-                n_heads : number of attention heads, must divie embed_dim
-                attn_length : length of the attention window
-                mlp_ratio : ratio of mlp hidden dim to embedding dim
-                dropout : (optional) dropout probability
-                embd_dropout : (optional) dropout probability for the embedding layer
-                configo = dict(vocab_size=vocab_size,n_layers=n_layers,embed_dim=embed_dim,n_heads=n_heads,
-                            attn_length=attn_length,mlp_ratio=mlp_ratio,dropout=dropout,embd_dropout=embd_dropout)
+        Args:
+            vocab_size: number of tokens in the vocabulary
+            n_layer: number of transformer layers
+            embed_dim: number of embedding dimensions
+            n_heads: number of attention heads, must divie embed_dim
+            attn_length: length of the attention window
+            mlp_ratio: ratio of mlp hidden dim to embedding dim
+            dropout: (optional) dropout probability
+            embd_dropout: (optional) dropout probability for the embedding layer
+            configo = dict(vocab_size=vocab_size,n_layers=n_layers,embed_dim=embed_dim,n_heads=n_heads,
+                        attn_length=attn_length,mlp_ratio=mlp_ratio,dropout=dropout,embd_dropout=embd_dropout)
         """
         configo = dict(vocab_size=vocab_size,n_layers=n_layers,embed_dim=embed_dim,n_heads=n_heads,
                             attn_length=attn_length,mlp_ratio=mlp_ratio,dropout=dropout,embd_dropout=embd_dropout)
@@ -73,12 +76,13 @@ class MinGPT(ConfigModule):
 
     def forward(self, idx)-> torch.Tensor:
         """
-            Process sequence of digits and outputs logits
+        Process sequence of digits and outputs logits
 
-            Args:
-            idx : (B,T) sequence of TOKENIZED text. Max token integer must be <= self.vocab_size
+        Args:
+            idx: (B,T) sequence of TOKENIZED text.
+                Max token integer must be <= self.vocab_size
 
-            Returns :
+        Returns:
             (B,T,vocab_size) Tensor of logits.
         """
         B, T = idx.shape
@@ -104,19 +108,25 @@ class MinGPT(ConfigModule):
     @torch.no_grad()
     def generate(self, idx, max_new_tokens, temperature=1.0, do_sample=False, top_k=None):
         """
-            Take a conditioning sequence of indices idx (LongTensor of shape (B,T)) and complete
-            the sequence max_new_tokens times, feeding the predictions back into the model each time.
-            Use with model in inference mode (apply model.eval() first)
+        Take a conditioning sequence of indices idx (LongTensor of shape (B,T))
+        and complete the sequence max_new_tokens times, feeding the predictions
+        back into the model each time. Use with model in inference mode (apply
+        model.eval() first)
 
-            Args :
-            idx : (B,T) tensor of context tokens. Mostly, it will be B=1 but can do in parallel also
-            max_new_tokens : number of tokens to generate on top of the conditioning sequence
-            temperature : softmax temperature (lower -> more conservative sampling)
-            do_sample : if True, use multinomial sampling. Otherwise use greedy decoding
-            top_k : if set to int > 0, only sample from the top k most probable logits
+        Args:
+            idx: (B,T) tensor of context tokens. Mostly, it will be B=1 but can
+                do in parallel also
+            max_new_tokens: number of tokens to generate on top of the
+                conditioning sequence
+            temperature: softmax temperature (lower -> more conservative
+                sampling)
+            do_sample: if True, use multinomial sampling. Otherwise use greedy
+                decoding
+            top_k: if set to int > 0, only sample from the top k most probable logits
 
-            Returns :
-            (B,T) LongTensor of generated token indices. Must still be decoded by tokenizer.
+        Returns:
+            (B,T) LongTensor of generated token indices. Must still be decoded
+            by tokenizer.
         """
 
         for _ in tqdm(range(max_new_tokens)):
@@ -125,22 +135,28 @@ class MinGPT(ConfigModule):
             idx = torch.cat((idx, idx_next), dim=1)
 
         return idx
-    
+
     @torch.no_grad()
     def generate_next_token(self,idx,temperature=1.0, do_sample=False, top_k=None):
         """
-            Take a conditioning sequence of indices idx (LongTensor of shape (B,T)) and complete
-            the sequence max_new_tokens times, feeding the predictions back into the model each time.
-            Use with model in inference mode (apply model.eval() first)
+        Take a conditioning sequence of indices idx (LongTensor of shape (B,T))
+        and complete the sequence max_new_tokens times, feeding the predictions
+        back into the model each time. Use with model in inference mode (apply
+        model.eval() first)
 
-            Args :
-            idx : (B,T) tensor of context tokens. Mostly, it will be B=1 but can do in parallel also
-            max_new_tokens : number of tokens to generate on top of the conditioning sequence
-            temperature : softmax temperature (lower -> more conservative sampling)
-            do_sample : if True, use multinomial sampling. Otherwise use greedy decoding
-            top_k : if set to int > 0, only sample from the top k most probable logits
+        Args:
+            idx: (B,T) tensor of context tokens. Mostly, it will be B=1 but can
+                do in parallel also
+            max_new_tokens: number of tokens to generate on top of the
+                conditioning sequence
+            temperature: softmax temperature (lower -> more conservative
+                sampling)
+            do_sample: if True, use multinomial sampling. Otherwise use greedy
+                decoding
+            top_k: if set to int > 0, only sample from the top k most probable
+                logits
 
-            Returns :
+        Returns:
             next predicted token, Long
         """
         idx_cond = idx if idx.shape[1] <= self.attn_length else idx[:, -self.attn_length:]
@@ -167,14 +183,15 @@ class MinGPT(ConfigModule):
 
 class CausalSelfAttention(DevModule):
     """
-        Multi-head masked self-attention layer. Maybe in the future, benchmark against
-        native pytorch implementation to make sure its not too slow/memory hungry
+    Multi-head masked self-attention layer. Maybe in the future, benchmark
+    against native pytorch implementation to make sure its not too slow/memory
+    hungry
 
-        Args :
-            embed_dim : number of embedding dimensions
-            n_heads : number of attention heads
-            attn_length : length of the attention window
-            dropout : (optional) dropout probability 
+    Args:
+        embed_dim: number of embedding dimensions
+        n_heads: number of attention heads
+        attn_length: length of the attention window
+        dropout: (optional) dropout probability
     """
 
     def __init__(self, embed_dim : int, n_heads :int, attn_length:int, dropout:float = 0.1):
@@ -220,15 +237,15 @@ class CausalSelfAttention(DevModule):
 
 
 class Block(DevModule):
-    """ 
-        One transformer block/layer, causal attention followed by a MLP.
+    """
+    One transformer block/layer, causal attention followed by a MLP.
 
-        Args :
-            embed_dim : number of embedding dimensions
-            n_heads : number of attention heads
-            attn_length : length of the attention window
-            mlp_ratio : ratio of mlp hidden dim to embedding dim
-            dropout : (optional) dropout probability
+    Args:
+        embed_dim: number of embedding dimensions
+        n_heads: number of attention heads
+        attn_length: length of the attention window
+        mlp_ratio: ratio of mlp hidden dim to embedding dim
+        dropout: (optional) dropout probability
     """
 
     def __init__(self, embed_dim :int, n_heads:int,attn_length:int, mlp_ratio:float,dropout:float=0.1):
@@ -244,7 +261,7 @@ class Block(DevModule):
             c_proj  = nn.Linear(int(mlp_ratio * embed_dim), embed_dim),
             dropout = nn.Dropout(dropout),
         ))
-        
+
 
     def forward(self, x):
         x = x + self.attn(self.ln_1(x))

--- a/modules/models/mingpt/MinGPT.py
+++ b/modules/models/mingpt/MinGPT.py
@@ -1,10 +1,16 @@
 """
 Full definition of a GPT Language Model.
 """
-import math, torch, torch.nn as nn
-from torch.nn import functional as F
-from torchenhanced import ConfigModule,DevModule
+
+import math
 from tqdm import tqdm
+
+import torch
+import torch.nn as nn
+from torch.nn import functional as F
+
+from torchenhanced import DevModule
+from torchenhanced import ConfigModule
 
 
 class MinGPT(ConfigModule):

--- a/modules/models/mingpt/MinGPT_Trainer.py
+++ b/modules/models/mingpt/MinGPT_Trainer.py
@@ -16,8 +16,8 @@ from ...tokenizer import Tokenizer
 
 
 class MinGPT_Trainer(Trainer):
-    def __init__(self, model: MinGPT, train_dataset: TokenText, valid_dataset : TokenText, backwards : bool=True, 
-                 detokenizer :Tokenizer=None, optim: Optimizer = None, scheduler: _LRScheduler = None, 
+    def __init__(self, model: MinGPT, train_dataset: TokenText, valid_dataset : TokenText, backwards : bool=True,
+                 detokenizer :Tokenizer=None, optim: Optimizer = None, scheduler: _LRScheduler = None,
                  state_save_loc=None, device: str = 'cpu',parallel=None, run_name: str = None, project_name: str = None,
                  run_config: dict ={}):
         super().__init__(model, optim, scheduler, save_loc=state_save_loc, device=device, parallel=parallel,
@@ -47,10 +47,10 @@ class MinGPT_Trainer(Trainer):
     def process_batch(self, batch_data):
         # Compute the loss, and log the learning rate
         loss = self.compute_loss(batch_data)
-        
+
         if(self.do_step_log) :
             self.logger.log({'lr' : self.scheduler.get_last_lr()[0]},commit=False)
-    
+
         return loss
 
     def compute_loss(self, batch_data):
@@ -76,7 +76,7 @@ class MinGPT_Trainer(Trainer):
 
     def valid_log(self):
         """
-            Log a snippet of generated text in a wandb Table
+        Log a snippet of generated text in a wandb Table
         """
         data, _ = self.valid_dataset[random.randint(0,len(self.valid_dataset)-1)] # (T,)*2
         data = data[:5].to(self.device) # only keep first 5 tokens, to start generating
@@ -93,10 +93,10 @@ class MinGPT_Trainer(Trainer):
         else :
             phrase_out=self.detokenizer.detokenize(phrase_out)
 
-        self.text_table.add_data(f"{self.steps_done/1000:.1f}k",phrase_out) 
+        self.text_table.add_data(f"{self.steps_done/1000:.1f}k",phrase_out)
         # Fucking wandb... To update the table before end, need to re-create one each time
         new_table = wandb.Table(
         columns=self.text_table.columns, data=self.text_table.data
         )
-        
+
         wandb.log({'gen_samples': new_table},commit=False)

--- a/modules/models/mingpt/MinGPT_Trainer.py
+++ b/modules/models/mingpt/MinGPT_Trainer.py
@@ -1,9 +1,15 @@
-import torch, torch.nn.functional as F
-from torch.optim.lr_scheduler import _LRScheduler
+import wandb
+import random
+
+import torch
+import torch.nn.functional as F
+
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
-import wandb, random
+from torch.optim.lr_scheduler import _LRScheduler
+
 from torchenhanced import Trainer
+
 from .MinGPT import MinGPT
 from ...datasets import TokenText
 from ...tokenizer import Tokenizer

--- a/modules/models/mingpt/__init__.py
+++ b/modules/models/mingpt/__init__.py
@@ -1,2 +1,2 @@
-from .MinGPT import MinGPT
-from .MinGPT_Trainer import MinGPT_Trainer
+from .MinGPT import MinGPT as MinGPT
+from .MinGPT_Trainer import MinGPT_Trainer as MinGPT_Trainer

--- a/modules/tok_utils/__init__.py
+++ b/modules/tok_utils/__init__.py
@@ -1,3 +1,3 @@
-from .create_custom_tokenizer import create_tokenizer
-from .pt_to_h5 import make_h5
-from .tokenize_to_pt import tokenize_folder
+from .create_custom_tokenizer import create_tokenizer as create_tokenizer
+from .pt_to_h5 import make_h5 as make_h5
+from .tokenize_to_pt import tokenize_folder as tokenize_folder

--- a/modules/tok_utils/create_custom_tokenizer.py
+++ b/modules/tok_utils/create_custom_tokenizer.py
@@ -1,9 +1,8 @@
 """
-    Contains the method necessary to train a Tokenizer with BPE.
-    Only work on a single .txt file. Should be no bigger than ~50 GB, to avoid
-    memory issues.
-    
-    File should contain regular spaces, otherwise it might crash with OOM error.
+Contains the method necessary to train a Tokenizer with BPE. Only work on a
+single .txt file. Should be no bigger than ~50 GB, to avoid memory issues.
+
+File should contain regular spaces, otherwise it might crash with OOM error.
 """
 
 import os
@@ -40,7 +39,7 @@ def read_in_lines(file_path, batch_size=512, phrase_size=2048):  # phrase_size i
         while not done:
             lines=[]
             newline=''
-            
+
             while (len(lines)<batch_size and not done):
                 while(len(newline)<=phrase_size):
                     #Read lines until we get something long enough
@@ -71,16 +70,20 @@ def read_in_lines(file_path, batch_size=512, phrase_size=2048):  # phrase_size i
 
 def create_tokenizer(txt_path, save_directory = None, tokenizer_name=None, vocab_size=50257):
     """
-        Creates a custom BPE huggingface tokenizer from a .txt file. The tokenizer is saved as a folder,
-        and can be loaded with the helper function 'get_tokenizer(m_path=<tokenizer folder>)' from modules/tokenizer.py.
-        Needs quite a bit of memory, depending on dataset size.
-        If the data has no spaces, it will probably crash with out of memory error.
+    Creates a custom BPE huggingface tokenizer from a .txt file. The tokenizer
+    is saved as a folder, and can be loaded with the helper function
+    `get_tokenizer(m_path=<tokenizer folder>)` from modules/tokenizer.py. Needs
+    quite a bit of memory, depending on dataset size. If the data has no
+    spaces, it will probably crash with out of memory error.
 
-        Args :
-        txt_path : Path to the .txt file to use for training the tokenizer.
-        save_directory : Directory where the tokenizer will be saved. If None, will be saved in the same directory as the .txt file.
-        tokenizer_name : Name of the tokenizer. If None, will be the name of the .txt file, followed by _tokenizer.
-        vocab_size : Size of the vocabulary to use for the tokenizer. Default is 50257, which is the GPT2 vocabulary size.
+    Args:
+        txt_path: Path to the .txt file to use for training the tokenizer.
+        save_directory: Directory where the tokenizer will be saved. If None,
+            will be saved in the same directory as the .txt file.
+        tokenizer_name: Name of the tokenizer. If None, will be the name of the
+            .txt file, followed by _tokenizer.
+        vocab_size: Size of the vocabulary to use for the tokenizer. Default is
+            50257, which is the GPT2 vocabulary size.
     """
     if save_directory is None:
         save_directory = os.path.dirname(txt_path)

--- a/modules/tok_utils/create_custom_tokenizer.py
+++ b/modules/tok_utils/create_custom_tokenizer.py
@@ -6,9 +6,8 @@
     File should contain regular spaces, otherwise it might crash with OOM error.
 """
 
-
-
 import os
+
 from transformers import AutoTokenizer
 
 

--- a/modules/tok_utils/pt_to_h5.py
+++ b/modules/tok_utils/pt_to_h5.py
@@ -27,7 +27,7 @@ def make_h5(pt_data_folder, dataset_fname = 'dataset.h5', destination_folder = N
 
     if(destination_folder is None):
         destination_folder= Path(__file__).parent.as_posix()
-    
+
     if not dataset_fname.endswith('.h5') : dataset_fname = f"{dataset_fname}.h5"
 
     tarname = os.path.join(destination_folder, dataset_fname)
@@ -36,7 +36,7 @@ def make_h5(pt_data_folder, dataset_fname = 'dataset.h5', destination_folder = N
     if(os.path.isdir(pt_data_folder)):
         with h5py.File(tarname, 'w') as f:
             dset = f.create_dataset("tokens", (0,), maxshape=(None,), dtype='int32')  # note the maxshape parameter
-            
+
             current_index = 0
             for file in tqdm(os.listdir(pt_data_folder)):
                 if os.path.splitext(file)[1]=='.pt':
@@ -47,10 +47,10 @@ def make_h5(pt_data_folder, dataset_fname = 'dataset.h5', destination_folder = N
                     print('snippet : \n', view_tokenizer.detokenize(tensor[:,:40]))
                     # Resize the dataset to accommodate the new data
                     dset.resize((current_index + length,))
-                    
+
                     # Add the new data to the dataset
                     dset[current_index:current_index+length] = tensor.numpy().squeeze()
-                    
+
                     # Update the current ind
                     current_index += length
     else :

--- a/modules/tok_utils/pt_to_h5.py
+++ b/modules/tok_utils/pt_to_h5.py
@@ -1,6 +1,10 @@
-import h5py , os, torch
-from pathlib import Path
+import os
+import h5py
 from tqdm import tqdm
+from pathlib import Path
+
+import torch
+
 from transformers import AutoTokenizer
 
 def make_h5(pt_data_folder, dataset_fname = 'dataset.h5', destination_folder = None, view_tokenizer : AutoTokenizer = None):

--- a/modules/tok_utils/pt_to_h5.py
+++ b/modules/tok_utils/pt_to_h5.py
@@ -3,14 +3,19 @@ from pathlib import Path
 from tqdm import tqdm
 from transformers import AutoTokenizer
 
-def make_h5(pt_data_folder, destination_folder = None, view_tokenizer : AutoTokenizer = None):
+def make_h5(pt_data_folder, dataset_fname = 'dataset.h5', destination_folder = None, view_tokenizer : AutoTokenizer = None):
     """
-        Takes a folder of .pt files, and converts them to a single .h5 file.
+    Takes a folder of .pt files, and converts them to a single .h5 file.
 
-        Args:
-            pt_data_folder : Path to the folder containing the .pt files. Can be relative or absolute.
-            destination_folder : Path to the folder where the .h5 file will be saved. Can be relative or absolute.
-            view_tokenizer : A tokenizer to use for viewing dataset snippets during conversion. If None, will use the GPT2 tokenizer.
+    Args:
+        pt_data_folder : Path to the folder containing the .pt files. Can be
+            relative or absolute.
+        dataset_fname : Name of the dataset file. Defaults to `dataset.h5`
+            ('.h5' will automatically be added at the end if missing).
+        destination_folder : Path to the folder where the .h5 file will be
+            saved. Can be relative or absolute.
+        view_tokenizer : A tokenizer to use for viewing dataset snippets
+            during conversion. If None, will use the GPT2 tokenizer.
     """
 
     if(view_tokenizer is None):
@@ -19,9 +24,10 @@ def make_h5(pt_data_folder, destination_folder = None, view_tokenizer : AutoToke
     if(destination_folder is None):
         destination_folder= Path(__file__).parent.as_posix()
     
-    tarname = os.path.join(destination_folder,f'{os.path.basename(pt_data_folder)}.h5')
-    os.makedirs(os.path.dirname(tarname),exist_ok=True)
+    if not dataset_fname.endswith('.h5') : dataset_fname = f"{dataset_fname}.h5"
 
+    tarname = os.path.join(destination_folder, dataset_fname)
+    os.makedirs(os.path.dirname(tarname),exist_ok=True)
 
     if(os.path.isdir(pt_data_folder)):
         with h5py.File(tarname, 'w') as f:

--- a/modules/tok_utils/tokenize_to_pt.py
+++ b/modules/tok_utils/tokenize_to_pt.py
@@ -13,9 +13,16 @@
     and can optionally skip preprocessing steps based on the command line arguments.
 
 """
-from modules import tokenizer
-import  os, torch, argparse, shutil,pathlib
+
+import os
+import shutil
+import pathlib
+import argparse
 from tqdm import tqdm
+
+import torch
+
+from modules import tokenizer
 
 MAX_SIZE = 2*1024*1024*1024 
 

--- a/modules/tok_utils/tokenize_to_pt.py
+++ b/modules/tok_utils/tokenize_to_pt.py
@@ -1,17 +1,23 @@
 """
-    Defines the methods needed for tokenizing of .txt files into .pt, given 
-    a pre-existing tokenizer.
+Defines the methods needed for tokenizing of .txt files into .pt, given
+a pre-existing tokenizer.
 
-    Can be used as a script. 
-    USAGE : python tokenize_to_pt.py <folder_path> -t <tokenizer_name> -p
-    Arguments:
-        folder_path (str): Mandatory. Path to the folder containing txt files to be tokenized.
-        --tokenizer_name, -t (str): Optional. Specifies the tokenizer by name. Defaults to 'gpt2' if not provided.
-        --no_preprocess, -p: Optional flag. If set, skips splitting and sanitizing the text files.
+Can be used as a script.
 
-    The script processes each text file in the directory with the specified or default tokenizer, 
-    and can optionally skip preprocessing steps based on the command line arguments.
+Usage:
+    python tokenize_to_pt.py <folder_path> -t <tokenizer_name> -p
 
+Arguments:
+    folder_path (str): Mandatory. Path to the folder containing txt files to be
+        tokenized.
+    --tokenizer_name, -t (str): Optional. Specifies the tokenizer by name.
+        Defaults to 'gpt2' if not provided.
+    --no_preprocess, -p: Optional flag. If set, skips splitting and sanitizing
+        the text files.
+
+The script processes each text file in the directory with the specified or
+default tokenizer, and can optionally skip preprocessing steps based on the
+command line arguments.
 """
 
 import os
@@ -24,7 +30,7 @@ import torch
 
 from modules import tokenizer
 
-MAX_SIZE = 2*1024*1024*1024 
+MAX_SIZE = 2*1024*1024*1024
 
 def replace_unusual_terminators(filename):
     """Replace unusual line terminators with standard newline."""
@@ -33,7 +39,7 @@ def replace_unusual_terminators(filename):
 
     with open(filename, 'r', encoding='utf-8') as f:
         data = f.read()
-    
+
         data = data.replace(LS, '\n').replace(PS, '\n')
 
         with open(filename, 'w', encoding='utf-8') as f:
@@ -82,16 +88,16 @@ def split_file(filename, split_dir):
                 target.write(data)
             print(f'Split {part_num*MAX_SIZE/1e9}GB so far')
             part_num += 1
-            
+
 
 def main_split_large(folder_path, target_path):
     """
-        Use split_file on a folder containing big .txt files.
-        Backs up the un-split text.
+    Use split_file on a folder containing big .txt files.
+    Backs up the un-split text.
 
-        Args:
-        folder_path : Path to the folder containing the .txt files to split.
-        target_path : Path to the folder that will contain the splits (created
+    Args:
+        folder_path: Path to the folder containing the .txt files to split.
+        target_path: Path to the folder that will contain the splits (created
             if needed).
     """
     folder_name = os.path.basename(os.path.normpath(folder_path))
@@ -108,25 +114,27 @@ def main_split_large(folder_path, target_path):
             else:
                 # Copy original file to split folder
                 shutil.copy(filepath, target_path)
-            
-            
+
+
 
 
 def tokenize_folder(folder_path, tokenizer_path=None, no_preprocess=False):
     """
-        Pipeline for tokenizing text in a folder. Is NOT recursive, will
-        act only on .txt files contained in folder_path.
+    Pipeline for tokenizing text in a folder. Is NOT recursive, will
+    act only on .txt files contained in folder_path.
 
-        Save the tensors containing the tokens as .pt files in a folder named
-        `folder_path`_pt (appending "_pt").
-        Each .pt file contains a tensor of shape [1, n_tokens], which
-        can be loaded with torch.load if needed.
-        
-        Args:
-        folder_path : Path to the folder containing the .txt files to tokenize.
-        tokenizer_path : Path to the tokenizer to use. If None, will use the default GPT2 tokenizer.
-        no_preprocess : If True, will not do the splitting and sanitization of the files. Default is False. 
-            (use True if tokenization crashed after sanitization, to not repeat preprocessing)
+    Save the tensors containing the tokens as .pt files in a folder named
+    `folder_path`_pt (appending "_pt"). Each .pt file contains a tensor of
+    shape [1, n_tokens], which can be loaded with torch.load if needed.
+
+    Args:
+        folder_path: Path to the folder containing the .txt files to
+            tokenize.
+        tokenizer_path: Path to the tokenizer to use. If None, will use the
+            default GPT2 tokenizer.
+        no_preprocess: If True, will not do the splitting and sanitization
+            of the files. Default is False. (use True if tokenization
+            crashed after sanitization, to not repeat preprocessing)
     """
     if(tokenizer_path is None):
         raise ValueError('Tokenizer path required, please specify with -t <tokenizer_path>')
@@ -146,7 +154,7 @@ def tokenize_folder(folder_path, tokenizer_path=None, no_preprocess=False):
         # Then remove strange terminators
         main_replace_unusual(target_path)
 
-    # Then run the tokenizer on the MAX_SIZE txt files : 
+    # Then run the tokenizer on the MAX_SIZE txt files :
     for txtfile in os.listdir(target_path):
         if(txtfile.endswith('.txt')):
             toki.tokenize_txt_file_to_pt_file(os.path.join(target_path,txtfile), f'{os.path.join(target_path,txtfile[:-4])}_tokenized.pt', dtype=torch.int32)

--- a/modules/tokenizer.py
+++ b/modules/tokenizer.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
-import os, pathlib, sys, gc
+
+import os
+import sys
 import json
-import numpy as np, torch
+import pathlib
 from tqdm import tqdm
-from transformers import AutoTokenizer, logging 
-from pathlib import Path
+
+import torch
+
+from transformers import logging
+from transformers import AutoTokenizer
 
 logging.set_verbosity_error() # needed to stop the stupid warning messages
 

--- a/pics/en-fr.train-valid.combined_with_inset.svg
+++ b/pics/en-fr.train-valid.combined_with_inset.svg
@@ -1,0 +1,1743 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="608.98125pt" height="321.95625pt" viewBox="0 0 608.98125 321.95625" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2024-03-25T13:06:10.877638</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.5.3, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 321.95625 
+L 608.98125 321.95625 
+L 608.98125 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 43.78125 284.4 
+L 601.78125 284.4 
+L 601.78125 7.2 
+L 43.78125 7.2 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="mc4d6831072" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mc4d6831072" x="60.250309" y="284.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0.0 -->
+      <g transform="translate(52.298747 298.998438)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#mc4d6831072" x="159.133882" y="284.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 20.0 -->
+      <g transform="translate(148.001069 298.998438)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#mc4d6831072" x="258.017454" y="284.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 40.0 -->
+      <g transform="translate(246.884642 298.998438)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mc4d6831072" x="356.901027" y="284.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 60.0 -->
+      <g transform="translate(345.768214 298.998438)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#mc4d6831072" x="455.784599" y="284.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 80.0 -->
+      <g transform="translate(444.651787 298.998438)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-2e" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="159.033203"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mc4d6831072" x="554.668172" y="284.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 100.0 -->
+      <g transform="translate(540.354109 298.998438)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-2e" x="190.869141"/>
+       <use xlink:href="#DejaVuSans-30" x="222.65625"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- samples seen (millions) -->
+     <g transform="translate(263.732031 312.676563)scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-73"/>
+      <use xlink:href="#DejaVuSans-61" x="52.099609"/>
+      <use xlink:href="#DejaVuSans-6d" x="113.378906"/>
+      <use xlink:href="#DejaVuSans-70" x="210.791016"/>
+      <use xlink:href="#DejaVuSans-6c" x="274.267578"/>
+      <use xlink:href="#DejaVuSans-65" x="302.050781"/>
+      <use xlink:href="#DejaVuSans-73" x="363.574219"/>
+      <use xlink:href="#DejaVuSans-20" x="415.673828"/>
+      <use xlink:href="#DejaVuSans-73" x="447.460938"/>
+      <use xlink:href="#DejaVuSans-65" x="499.560547"/>
+      <use xlink:href="#DejaVuSans-65" x="561.083984"/>
+      <use xlink:href="#DejaVuSans-6e" x="622.607422"/>
+      <use xlink:href="#DejaVuSans-20" x="685.986328"/>
+      <use xlink:href="#DejaVuSans-28" x="717.773438"/>
+      <use xlink:href="#DejaVuSans-6d" x="756.787109"/>
+      <use xlink:href="#DejaVuSans-69" x="854.199219"/>
+      <use xlink:href="#DejaVuSans-6c" x="881.982422"/>
+      <use xlink:href="#DejaVuSans-6c" x="909.765625"/>
+      <use xlink:href="#DejaVuSans-69" x="937.548828"/>
+      <use xlink:href="#DejaVuSans-6f" x="965.332031"/>
+      <use xlink:href="#DejaVuSans-6e" x="1026.513672"/>
+      <use xlink:href="#DejaVuSans-73" x="1089.892578"/>
+      <use xlink:href="#DejaVuSans-29" x="1141.992188"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_7">
+      <defs>
+       <path id="md5c1eca6cb" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#md5c1eca6cb" x="43.78125" y="267.963706" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 2.8 -->
+      <g transform="translate(20.878125 271.762925)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-38" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#md5c1eca6cb" x="43.78125" y="235.044517" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 2.9 -->
+      <g transform="translate(20.878125 238.843736)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-39" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#md5c1eca6cb" x="43.78125" y="202.125328" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 3.0 -->
+      <g transform="translate(20.878125 205.924546)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#md5c1eca6cb" x="43.78125" y="169.206138" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 3.1 -->
+      <g transform="translate(20.878125 173.005357)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-31" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#md5c1eca6cb" x="43.78125" y="136.286949" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 3.2 -->
+      <g transform="translate(20.878125 140.086168)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#md5c1eca6cb" x="43.78125" y="103.36776" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 3.3 -->
+      <g transform="translate(20.878125 107.166978)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-33" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#md5c1eca6cb" x="43.78125" y="70.44857" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 3.4 -->
+      <g transform="translate(20.878125 74.247789)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-34" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#md5c1eca6cb" x="43.78125" y="37.529381" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 3.5 -->
+      <g transform="translate(20.878125 41.3286)scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_16">
+     <!-- loss -->
+     <g transform="translate(14.798438 155.457813)rotate(-90)scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-6c"/>
+      <use xlink:href="#DejaVuSans-6f" x="27.783203"/>
+      <use xlink:href="#DejaVuSans-73" x="88.964844"/>
+      <use xlink:href="#DejaVuSans-73" x="141.064453"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_15">
+    <path d="M 69.144886 22.752849 
+L 78.044408 87.504968 
+L 86.943929 117.394354 
+L 95.843451 136.207322 
+L 104.742972 149.720115 
+L 113.642494 160.597704 
+L 122.542016 169.554444 
+L 131.441537 177.016243 
+L 140.341059 183.839775 
+L 149.24058 189.599595 
+L 158.140102 194.087285 
+L 167.039623 197.663562 
+L 175.939145 200.204992 
+L 184.838666 201.66441 
+L 193.738188 202.238065 
+L 202.637709 179.247894 
+L 211.537231 182.735504 
+L 220.436752 186.791352 
+L 229.336274 191.043092 
+L 238.235795 195.318737 
+L 247.135317 200.002507 
+L 256.034839 204.323521 
+L 264.93436 208.367074 
+L 273.833882 212.28145 
+L 282.733403 215.914807 
+L 291.632925 219.043339 
+L 300.532446 221.155847 
+L 309.431968 222.888111 
+L 318.331489 223.90795 
+L 327.231011 224.360038 
+L 336.130532 205.916135 
+L 345.030054 206.548267 
+L 353.929575 208.292056 
+L 362.829097 211.237109 
+L 371.728618 213.922771 
+L 380.62814 216.782196 
+L 389.527661 220.161979 
+L 398.427183 223.213793 
+L 407.326705 225.98054 
+L 416.226226 228.853932 
+L 425.125748 231.017753 
+L 434.025269 233.026873 
+L 442.924791 234.304626 
+L 451.824312 235.069175 
+L 460.723834 235.433128 
+L 469.623355 220.14109 
+L 478.522877 220.055574 
+L 487.422398 221.257141 
+L 496.32192 223.141866 
+L 505.221441 225.222713 
+L 514.120963 227.446584 
+L 523.020484 230.045771 
+L 531.920006 232.490276 
+L 540.819528 234.93959 
+L 549.719049 237.041944 
+L 558.618571 239.032246 
+L 567.518092 240.528769 
+L 576.417614 241.571494 
+" clip-path="url(#pcbbaca6579)" style="fill: none; stroke: #ff00ff; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_16">
+    <path d="M 69.144886 19.8 
+L 78.044408 84.371193 
+L 86.943929 113.919372 
+L 95.843451 132.178333 
+L 104.742972 145.480206 
+L 113.642494 156.111593 
+L 122.542016 165.013245 
+L 131.441537 172.597128 
+L 140.341059 179.005233 
+L 149.24058 184.6105 
+L 158.140102 189.202948 
+L 167.039623 192.662503 
+L 175.939145 195.257598 
+L 184.838666 196.515175 
+L 193.738188 197.194253 
+L 202.637709 174.600263 
+L 211.537231 177.578711 
+L 220.436752 181.828457 
+L 229.336274 185.852194 
+L 238.235795 189.991844 
+L 247.135317 194.535677 
+L 256.034839 198.840512 
+L 264.93436 202.839189 
+L 273.833882 206.524215 
+L 282.733403 210.017347 
+L 291.632925 212.958211 
+L 300.532446 215.381138 
+L 309.431968 216.912554 
+L 318.331489 217.936214 
+L 327.231011 218.316818 
+L 336.130532 199.98358 
+L 345.030054 200.752249 
+L 353.929575 202.257014 
+L 362.829097 204.921471 
+L 371.728618 207.444754 
+L 380.62814 210.525326 
+L 389.527661 213.466526 
+L 398.427183 216.639945 
+L 407.326705 219.075832 
+L 416.226226 222.221158 
+L 425.125748 224.444865 
+L 434.025269 226.353095 
+L 442.924791 227.572737 
+L 451.824312 228.342244 
+L 460.723834 228.672829 
+L 469.623355 213.244269 
+L 478.522877 213.44111 
+L 487.422398 214.165146 
+L 496.32192 216.221934 
+L 505.221441 218.407836 
+L 514.120963 220.516392 
+L 523.020484 222.953056 
+L 531.920006 225.487019 
+L 540.819528 227.774393 
+L 549.719049 229.796893 
+L 558.618571 231.80665 
+L 567.518092 233.382782 
+L 576.417614 234.390426 
+" clip-path="url(#pcbbaca6579)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #ff00ff; stroke-width: 1.5"/>
+   </g>
+   <g id="line2d_17">
+    <path d="M 69.144886 56.070124 
+L 78.044408 121.729191 
+L 86.943929 151.408386 
+L 95.843451 169.684223 
+L 104.742972 183.439005 
+L 113.642494 193.963171 
+L 122.542016 202.83547 
+L 131.441537 210.530184 
+L 140.341059 217.045404 
+L 149.24058 222.616662 
+L 158.140102 227.147968 
+L 167.039623 230.666497 
+L 175.939145 233.111575 
+L 184.838666 234.550589 
+L 193.738188 235.171197 
+L 202.637709 212.182495 
+L 211.537231 215.166668 
+L 220.436752 219.182503 
+L 229.336274 223.246702 
+L 238.235795 227.760228 
+L 247.135317 232.26089 
+L 256.034839 236.246307 
+L 264.93436 240.595818 
+L 273.833882 244.247748 
+L 282.733403 247.561927 
+L 291.632925 250.576101 
+L 300.532446 252.972199 
+L 309.431968 254.608436 
+L 318.331489 255.568804 
+L 327.231011 255.98903 
+L 336.130532 237.298879 
+L 345.030054 238.082461 
+L 353.929575 239.861458 
+L 362.829097 242.248953 
+L 371.728618 245.184903 
+L 380.62814 247.967463 
+L 389.527661 251.079711 
+L 398.427183 254.220013 
+L 407.326705 257.044342 
+L 416.226226 259.684569 
+L 425.125748 261.919186 
+L 434.025269 263.822067 
+L 442.924791 265.037323 
+L 451.824312 265.847708 
+L 460.723834 266.211116 
+L 469.623355 250.71697 
+L 478.522877 250.67603 
+L 487.422398 252.098205 
+L 496.32192 253.601351 
+L 505.221441 255.548243 
+L 514.120963 257.853995 
+L 523.020484 260.407771 
+L 531.920006 262.902456 
+L 540.819528 265.166311 
+L 549.719049 267.378923 
+L 558.618571 269.240494 
+L 567.518092 270.705724 
+L 576.417614 271.8 
+" clip-path="url(#pcbbaca6579)" style="fill: none; stroke: #00ff00; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_18">
+    <path d="M 69.144886 30.395646 
+L 78.044408 95.814898 
+L 86.943929 125.454787 
+L 95.843451 143.512835 
+L 104.742972 156.705494 
+L 113.642494 167.506368 
+L 122.542016 176.314751 
+L 131.441537 183.655304 
+L 140.341059 190.184245 
+L 149.24058 195.811653 
+L 158.140102 200.31606 
+L 167.039623 203.766717 
+L 175.939145 206.179285 
+L 184.838666 207.577363 
+L 193.738188 208.156359 
+L 202.637709 186.190752 
+L 211.537231 189.065675 
+L 220.436752 193.253337 
+L 229.336274 197.793835 
+L 238.235795 202.017217 
+L 247.135317 206.477661 
+L 256.034839 210.754543 
+L 264.93436 214.698329 
+L 273.833882 218.75704 
+L 282.733403 222.045756 
+L 291.632925 224.83949 
+L 300.532446 227.349182 
+L 309.431968 228.943505 
+L 318.331489 229.8729 
+L 327.231011 230.331614 
+L 336.130532 212.077232 
+L 345.030054 212.930495 
+L 353.929575 214.826064 
+L 362.829097 217.460213 
+L 371.728618 220.368474 
+L 380.62814 223.468278 
+L 389.527661 226.208016 
+L 398.427183 229.452968 
+L 407.326705 232.173919 
+L 416.226226 234.954114 
+L 425.125748 237.269351 
+L 434.025269 239.054012 
+L 442.924791 240.280546 
+L 451.824312 241.050706 
+L 460.723834 241.397749 
+L 469.623355 226.409165 
+L 478.522877 226.412954 
+L 487.422398 227.492624 
+L 496.32192 229.298066 
+L 505.221441 231.49312 
+L 514.120963 233.802009 
+L 523.020484 236.174698 
+L 531.920006 238.861758 
+L 540.819528 241.145248 
+L 549.719049 243.221389 
+L 558.618571 245.09049 
+L 567.518092 246.623599 
+L 576.417614 247.709762 
+" clip-path="url(#pcbbaca6579)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #00ff00; stroke-width: 1.5"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 43.78125 284.4 
+L 43.78125 7.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 601.78125 284.4 
+L 601.78125 7.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 43.78125 284.4 
+L 601.78125 284.4 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 43.78125 7.2 
+L 601.78125 7.2 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="legend_1">
+    <g id="patch_7">
+     <path d="M 50.78125 279.4 
+L 149.984375 279.4 
+Q 151.984375 279.4 151.984375 277.4 
+L 151.984375 219.6875 
+Q 151.984375 217.6875 149.984375 217.6875 
+L 50.78125 217.6875 
+Q 48.78125 217.6875 48.78125 219.6875 
+L 48.78125 277.4 
+Q 48.78125 279.4 50.78125 279.4 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_19">
+     <path d="M 52.78125 225.785938 
+L 62.78125 225.785938 
+L 72.78125 225.785938 
+" style="fill: none; stroke: #ff00ff; stroke-width: 1.5; stroke-linecap: square"/>
+    </g>
+    <g id="text_17">
+     <!-- en, forward -->
+     <g transform="translate(80.78125 229.285938)scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-65"/>
+      <use xlink:href="#DejaVuSans-6e" x="61.523438"/>
+      <use xlink:href="#DejaVuSans-2c" x="124.902344"/>
+      <use xlink:href="#DejaVuSans-20" x="156.689453"/>
+      <use xlink:href="#DejaVuSans-66" x="188.476562"/>
+      <use xlink:href="#DejaVuSans-6f" x="223.681641"/>
+      <use xlink:href="#DejaVuSans-72" x="284.863281"/>
+      <use xlink:href="#DejaVuSans-77" x="325.976562"/>
+      <use xlink:href="#DejaVuSans-61" x="407.763672"/>
+      <use xlink:href="#DejaVuSans-72" x="469.042969"/>
+      <use xlink:href="#DejaVuSans-64" x="508.40625"/>
+     </g>
+    </g>
+    <g id="line2d_20">
+     <path d="M 52.78125 240.464063 
+L 62.78125 240.464063 
+L 72.78125 240.464063 
+" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #ff00ff; stroke-width: 1.5"/>
+    </g>
+    <g id="text_18">
+     <!-- en, backward -->
+     <g transform="translate(80.78125 243.964063)scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-65"/>
+      <use xlink:href="#DejaVuSans-6e" x="61.523438"/>
+      <use xlink:href="#DejaVuSans-2c" x="124.902344"/>
+      <use xlink:href="#DejaVuSans-20" x="156.689453"/>
+      <use xlink:href="#DejaVuSans-62" x="188.476562"/>
+      <use xlink:href="#DejaVuSans-61" x="251.953125"/>
+      <use xlink:href="#DejaVuSans-63" x="313.232422"/>
+      <use xlink:href="#DejaVuSans-6b" x="368.212891"/>
+      <use xlink:href="#DejaVuSans-77" x="426.123047"/>
+      <use xlink:href="#DejaVuSans-61" x="507.910156"/>
+      <use xlink:href="#DejaVuSans-72" x="569.189453"/>
+      <use xlink:href="#DejaVuSans-64" x="608.552734"/>
+     </g>
+    </g>
+    <g id="line2d_21">
+     <path d="M 52.78125 255.142188 
+L 62.78125 255.142188 
+L 72.78125 255.142188 
+" style="fill: none; stroke: #00ff00; stroke-width: 1.5; stroke-linecap: square"/>
+    </g>
+    <g id="text_19">
+     <!-- fr, forward -->
+     <g transform="translate(80.78125 258.642188)scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-66"/>
+      <use xlink:href="#DejaVuSans-72" x="35.205078"/>
+      <use xlink:href="#DejaVuSans-2c" x="76.318359"/>
+      <use xlink:href="#DejaVuSans-20" x="108.105469"/>
+      <use xlink:href="#DejaVuSans-66" x="139.892578"/>
+      <use xlink:href="#DejaVuSans-6f" x="175.097656"/>
+      <use xlink:href="#DejaVuSans-72" x="236.279297"/>
+      <use xlink:href="#DejaVuSans-77" x="277.392578"/>
+      <use xlink:href="#DejaVuSans-61" x="359.179688"/>
+      <use xlink:href="#DejaVuSans-72" x="420.458984"/>
+      <use xlink:href="#DejaVuSans-64" x="459.822266"/>
+     </g>
+    </g>
+    <g id="line2d_22">
+     <path d="M 52.78125 269.820313 
+L 62.78125 269.820313 
+L 72.78125 269.820313 
+" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #00ff00; stroke-width: 1.5"/>
+    </g>
+    <g id="text_20">
+     <!-- fr, backward -->
+     <g transform="translate(80.78125 273.320313)scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-66"/>
+      <use xlink:href="#DejaVuSans-72" x="35.205078"/>
+      <use xlink:href="#DejaVuSans-2c" x="76.318359"/>
+      <use xlink:href="#DejaVuSans-20" x="108.105469"/>
+      <use xlink:href="#DejaVuSans-62" x="139.892578"/>
+      <use xlink:href="#DejaVuSans-61" x="203.369141"/>
+      <use xlink:href="#DejaVuSans-63" x="264.648438"/>
+      <use xlink:href="#DejaVuSans-6b" x="319.628906"/>
+      <use xlink:href="#DejaVuSans-77" x="377.539062"/>
+      <use xlink:href="#DejaVuSans-61" x="459.326172"/>
+      <use xlink:href="#DejaVuSans-72" x="520.605469"/>
+      <use xlink:href="#DejaVuSans-64" x="559.96875"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_8">
+    <path d="M 241.78125 172.8 
+L 598.18125 172.8 
+L 598.18125 10.8 
+L 241.78125 10.8 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_7">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#mc4d6831072" x="288.619548" y="172.8" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 0.5 -->
+      <g transform="translate(280.667985 187.398438)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#mc4d6831072" x="336.491888" y="172.8" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 1.0 -->
+      <g transform="translate(328.540326 187.398438)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#mc4d6831072" x="384.364229" y="172.8" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 1.5 -->
+      <g transform="translate(376.412666 187.398438)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#mc4d6831072" x="432.236569" y="172.8" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 2.0 -->
+      <g transform="translate(424.285007 187.398438)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#mc4d6831072" x="480.10891" y="172.8" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- 2.5 -->
+      <g transform="translate(472.157347 187.398438)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#mc4d6831072" x="527.98125" y="172.8" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_26">
+      <!-- 3.0 -->
+      <g transform="translate(520.029688 187.398438)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#mc4d6831072" x="575.85359" y="172.8" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <!-- 3.5 -->
+      <g transform="translate(567.902028 187.398438)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_9">
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#md5c1eca6cb" x="241.78125" y="151.542688" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_28">
+      <!-- 3.5 -->
+      <g transform="translate(218.878125 155.341907)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#md5c1eca6cb" x="241.78125" y="117.600797" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <!-- 4.0 -->
+      <g transform="translate(218.878125 121.400015)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#md5c1eca6cb" x="241.78125" y="83.658905" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_30">
+      <!-- 4.5 -->
+      <g transform="translate(218.878125 87.458124)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#md5c1eca6cb" x="241.78125" y="49.717014" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <!-- 5.0 -->
+      <g transform="translate(218.878125 53.516233)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#md5c1eca6cb" x="241.78125" y="15.775122" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_32">
+      <!-- 5.5 -->
+      <g transform="translate(218.878125 19.574341)scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-35" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_35">
+    <path d="M 257.98125 24.540342 
+L 261.428059 38.270248 
+L 264.874867 49.725114 
+L 268.321676 59.64483 
+L 271.768484 68.044252 
+L 275.215293 76.40734 
+L 278.662101 83.595249 
+L 282.10891 90.36308 
+L 285.555718 96.020623 
+L 289.002527 101.275644 
+L 292.449335 105.126464 
+L 295.896144 109.241691 
+L 299.342952 112.553742 
+L 302.789761 115.384745 
+L 306.236569 118.159718 
+L 309.683378 120.627567 
+L 313.130186 122.94221 
+L 316.576995 124.985737 
+L 320.023803 126.828906 
+L 323.470612 128.772203 
+L 326.91742 130.206423 
+L 330.364229 131.645568 
+L 333.811037 133.344576 
+L 337.257846 134.493015 
+L 340.704654 135.719804 
+L 344.151463 136.801499 
+L 347.598271 137.954426 
+L 351.04508 139.078638 
+L 354.491888 140.324512 
+L 357.938697 141.269845 
+L 361.385505 142.062158 
+L 364.832314 142.641655 
+L 368.279122 143.521171 
+L 371.725931 144.661529 
+L 375.172739 145.200049 
+L 378.619548 145.998049 
+L 382.066356 146.575059 
+L 385.513165 147.4994 
+L 388.959973 147.815161 
+L 392.406782 148.675138 
+L 395.85359 149.125449 
+L 399.300399 149.73375 
+L 402.747207 150.24628 
+L 406.194016 150.501792 
+L 409.640824 151.118924 
+L 413.087633 151.381035 
+L 416.534441 152.268342 
+L 419.98125 152.764481 
+L 423.428059 153.214436 
+L 426.874867 153.541265 
+L 430.321676 154.281513 
+L 433.768484 154.242933 
+L 437.215293 154.868602 
+L 440.662101 155.164065 
+L 444.10891 155.710583 
+L 447.555718 156.029497 
+L 451.002527 156.157564 
+L 454.449335 156.594828 
+L 457.896144 156.986037 
+L 461.342952 157.476097 
+L 464.789761 157.280461 
+L 468.236569 157.946238 
+L 471.683378 158.164936 
+L 475.130186 158.26764 
+L 478.576995 158.693132 
+L 482.023803 159.177896 
+L 485.470612 159.159109 
+L 488.91742 159.742929 
+L 492.364229 160.104976 
+L 495.811037 160.167632 
+L 499.257846 160.552835 
+L 502.704654 160.830332 
+L 506.151463 161.145838 
+L 509.598271 161.185271 
+L 513.04508 161.617199 
+L 516.491888 161.711519 
+L 519.938697 161.69193 
+L 523.385505 162.233467 
+L 526.832314 162.084334 
+L 530.279122 162.631681 
+L 533.725931 162.692598 
+L 537.172739 163.079292 
+L 540.619548 163.315542 
+L 544.066356 163.242846 
+L 547.513165 163.601521 
+L 550.959973 163.848689 
+L 554.406782 164.116536 
+L 557.85359 164.442251 
+L 561.300399 164.435996 
+L 564.747207 164.555546 
+L 568.194016 164.676144 
+L 571.640824 164.90687 
+L 575.087633 164.958246 
+L 578.534441 165.293415 
+L 581.98125 165.436364 
+" clip-path="url(#p0722e6e581)" style="fill: none; stroke: #00ff00; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_36">
+    <path d="M 257.98125 18.163636 
+L 261.428059 32.162311 
+L 264.874867 44.898644 
+L 268.321676 55.901077 
+L 271.768484 65.0143 
+L 275.215293 73.803108 
+L 278.662101 81.182728 
+L 282.10891 87.862369 
+L 285.555718 93.314168 
+L 289.002527 98.336048 
+L 292.449335 101.946828 
+L 295.896144 105.84862 
+L 299.342952 108.875372 
+L 302.789761 111.623691 
+L 306.236569 114.196544 
+L 309.683378 116.556653 
+L 313.130186 118.649933 
+L 316.576995 120.589804 
+L 320.023803 122.278335 
+L 323.470612 124.151071 
+L 326.91742 125.506105 
+L 330.364229 126.863562 
+L 333.811037 128.487673 
+L 337.257846 129.591459 
+L 340.704654 130.808655 
+L 344.151463 131.762256 
+L 347.598271 132.888783 
+L 351.04508 133.99151 
+L 354.491888 135.229963 
+L 357.938697 136.069042 
+L 361.385505 136.882488 
+L 364.832314 137.44447 
+L 368.279122 138.295674 
+L 371.725931 139.421623 
+L 375.172739 139.944241 
+L 378.619548 140.731382 
+L 382.066356 141.334138 
+L 385.513165 142.155753 
+L 388.959973 142.558184 
+L 392.406782 143.315346 
+L 395.85359 143.805346 
+L 399.300399 144.398733 
+L 402.747207 144.894661 
+L 406.194016 145.141123 
+L 409.640824 145.740188 
+L 413.087633 146.030742 
+L 416.534441 146.862867 
+L 419.98125 147.391455 
+L 423.428059 147.77485 
+L 426.874867 148.119698 
+L 430.321676 148.841573 
+L 433.768484 148.792461 
+L 437.215293 149.457798 
+L 440.662101 149.748446 
+L 444.10891 150.292846 
+L 447.555718 150.640653 
+L 451.002527 150.747272 
+L 454.449335 151.157183 
+L 457.896144 151.551315 
+L 461.342952 151.959577 
+L 464.789761 151.786793 
+L 468.236569 152.531752 
+L 471.683378 152.70139 
+L 475.130186 152.828062 
+L 478.576995 153.221433 
+L 482.023803 153.723095 
+L 485.470612 153.727511 
+L 488.91742 154.278857 
+L 492.364229 154.676633 
+L 495.811037 154.704215 
+L 499.257846 155.074228 
+L 502.704654 155.291962 
+L 506.151463 155.685946 
+L 509.598271 155.681518 
+L 513.04508 156.083786 
+L 516.491888 156.194897 
+L 519.938697 156.208004 
+L 523.385505 156.719604 
+L 526.832314 156.569491 
+L 530.279122 157.124827 
+L 533.725931 157.211571 
+L 537.172739 157.550416 
+L 540.619548 157.844669 
+L 544.066356 157.709997 
+L 547.513165 158.097327 
+L 550.959973 158.365218 
+L 554.406782 158.587461 
+L 557.85359 158.957096 
+L 561.300399 158.931635 
+L 564.747207 159.040272 
+L 568.194016 159.154898 
+L 571.640824 159.396924 
+L 575.087633 159.459233 
+L 578.534441 159.766757 
+L 581.98125 159.91478 
+" clip-path="url(#p0722e6e581)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #00ff00; stroke-width: 1.5"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 241.78125 172.8 
+L 241.78125 10.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 598.18125 172.8 
+L 598.18125 10.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 241.78125 172.8 
+L 598.18125 172.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 241.78125 10.8 
+L 598.18125 10.8 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pcbbaca6579">
+   <rect x="43.78125" y="7.2" width="558" height="277.2"/>
+  </clipPath>
+  <clipPath id="p0722e6e581">
+   <rect x="241.78125" y="10.8" width="356.4" height="162"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/tokenize_to_h5.py
+++ b/tokenize_to_h5.py
@@ -30,7 +30,7 @@ def txt_to_h5(txt_path, out_h5_folder, tokenizer_folder, tokenizer_name):
     create_tokenizer(txt_path, tokenizer_folder,tokenizer_name=tokenizer_name)
     tokenize_folder(os.path.dirname(txt_path), os.path.join(tokenizer_folder,tokenizer_name))
     toki = get_tokenizer(m_path=os.path.join(tokenizer_folder,tokenizer_name))
-    make_h5(os.path.dirname(txt_path), out_h5_folder,toki)
+    make_h5(os.path.dirname(txt_path), os.path.splitext(os.path.basename(txt_path))[0], out_h5_folder,toki)
 
 
 if __name__=='__main__':
@@ -42,7 +42,7 @@ if __name__=='__main__':
         file for training.
 
         To make one of those things independently (e.g., only make the custom
-        tokenizer), see modules/tok_utils
+        tokenizer), see modules/tok_utils.
         """,
         formatter_class=argparse.RawTextHelpFormatter,
     )
@@ -56,10 +56,9 @@ if __name__=='__main__':
         items:
         1) given the path of a source plain text file, a folder of the same
         name as the containing folder of txt_path, with '_h5' appended at the
-        end, as well as raw Pytorch tensors and a backup. Example:
-            -t code_dataset/input.txt -> code_dataset_h5/code_dataset.h5
-                                         code_dataset_backup/input.txt
-                                         code_dataset/input_tokenized.pt
+        end, as well as raw Pytorch tensors. Example:
+            -t my_dataset/input.txt -> my_dataset_h5/input.h5
+                                       my_dataset_pt/input_tokenized.pt
         2) a tokenizer in modules/tokenizers called after the folder containing
         the txt dataset. Example:
             -t code_dataset/input.txt -> modules/tokenizers/code_dataset_tokenizer/

--- a/tokenize_to_h5.py
+++ b/tokenize_to_h5.py
@@ -1,9 +1,11 @@
 """
-    Script for preparing a .txt cc-100 dataset for training.
-    Creates the custom tokenizer, and tokenizes the text with it to generate the
-    .h5 file for training.
+Script for preparing a .txt cc-100 dataset for training.
 
-    To make one of those things independently (e.g., only make the custom tokenizer), see modules/tok_utils
+Creates the custom tokenizer, and tokenizes the text with it to generate the
+.h5 file for training.
+
+To make one of those things independently (e.g., only make the custom
+tokenizer), see modules/tok_utils.
 """
 
 import os
@@ -17,20 +19,20 @@ from modules import get_tokenizer
 
 
 def txt_to_h5(txt_path, out_h5_folder, tokenizer_folder, tokenizer_name):
-    """ 
-        Given a .txt file located ALONE inside a folder, trains a BPE tokenizer on it. 
-        Then, tokenizes the .txt file, and save the result as a an .h5 file, which can be used to 
-        make a TokenTextBOS dataset. NOTE: There are NO checkpoints, if it crashes
-        at any point, you have to start over. To avoid this, use instead the functions
-        'create_tokenizer', 'tokenize_folder' and 'make_h5' separately.
+    """
+    Given a .txt file located ALONE inside a folder, trains a BPE tokenizer on
+    it. Then, tokenizes the .txt file, and save the result as a an .h5 file,
+    which can be used to make a TokenTextBOS dataset.
 
-        The original .txt file will be saved inside a folder name <txt_path_folder>_backup
+    NOTE: There are NO checkpoints, if it crashes at any point, you have to
+    start over. To avoid this, use instead the functions 'create_tokenizer',
+    'tokenize_folder' and 'make_h5' separately.
 
-        Args:
-            txt_path (str): Path to the (single) .txt file to be tokenized
-            out_h5_folder (str): Folder to the output .h5 file
-            tokenizer_folder (str): Folder where the tokenizer will be saved
-            tokenizer_name (str): Name of the tokenizer that will be saved
+    Args:
+        txt_path (str): Path to the (single) .txt file to be tokenized
+        out_h5_folder (str): Folder to the output .h5 file
+        tokenizer_folder (str): Folder where the tokenizer will be saved
+        tokenizer_name (str): Name of the tokenizer that will be saved
     """
     create_tokenizer(txt_path, tokenizer_folder,tokenizer_name=tokenizer_name)
     tokenize_folder(os.path.dirname(txt_path), os.path.join(tokenizer_folder,tokenizer_name))

--- a/tokenize_to_h5.py
+++ b/tokenize_to_h5.py
@@ -5,10 +5,15 @@
 
     To make one of those things independently (e.g., only make the custom tokenizer), see modules/tok_utils
 """
-from modules.tok_utils import create_tokenizer,make_h5,tokenize_folder
-from modules import get_tokenizer
-import argparse
+
 import os
+import argparse
+
+from modules.tok_utils import make_h5
+from modules.tok_utils import tokenize_folder
+from modules.tok_utils import create_tokenizer
+
+from modules import get_tokenizer
 
 
 def txt_to_h5(txt_path, out_h5_folder, tokenizer_folder, tokenizer_name):

--- a/tokenize_to_h5.py
+++ b/tokenize_to_h5.py
@@ -40,22 +40,29 @@ if __name__=='__main__':
         Script for preparing a .txt cc-100 dataset for training. Creates the
         custom tokenizer, and tokenizes the text with it to generate the .h5
         file for training.
+
         To make one of those things independently (e.g., only make the custom
         tokenizer), see modules/tok_utils
-        """
+        """,
+        formatter_class=argparse.RawTextHelpFormatter,
     )
 
     parser.add_argument(
         "--txt_path", "-t",
         type=str,
         required=True,
-        help="""The input file to be tokenized. This script will save the
-        following items:
-        - a folder of the same name as the containing folder of txt_path, with
-        '_h5' append. Example: 'code_dataset/input.txt -> code_dataset_h5/
-        - a tokenizer in modules/tokenizers called after the folder containing
-        the txt dataset. example: 'code_dataset/input.txt ->
-        modules/tokenizers/code_dataset_tokenizer/
+        help="""
+        The input file to be tokenized. This script will save the following
+        items:
+        1) given the path of a source plain text file, a folder of the same
+        name as the containing folder of txt_path, with '_h5' appended at the
+        end, as well as raw Pytorch tensors and a backup. Example:
+            -t code_dataset/input.txt -> code_dataset_h5/code_dataset.h5
+                                         code_dataset_backup/input.txt
+                                         code_dataset/input_tokenized.pt
+        2) a tokenizer in modules/tokenizers called after the folder containing
+        the txt dataset. Example:
+            -t code_dataset/input.txt -> modules/tokenizers/code_dataset_tokenizer/
         """,
     )
 

--- a/tokenize_to_h5.py
+++ b/tokenize_to_h5.py
@@ -7,6 +7,7 @@
 """
 from modules.tok_utils import create_tokenizer,make_h5,tokenize_folder
 from modules import get_tokenizer
+import argparse
 import os
 
 
@@ -33,10 +34,38 @@ def txt_to_h5(txt_path, out_h5_folder, tokenizer_folder, tokenizer_name):
 
 
 if __name__=='__main__':
-    txt_path = 'shake/shakespeare.txt' # Path to the .txt file to be tokenized
-    out_h5_folder = 'h5datashake' #  Folder that will contain the output .h5 file
-    tokenizer_folder = 'modules/tokenizers' # Folder where the tokenizer will be saved
-    tokenizer_name = 'shakespear' # Name of the tokenizer that will be saved
+
+    parser = argparse.ArgumentParser(
+        description="""
+        Script for preparing a .txt cc-100 dataset for training. Creates the
+        custom tokenizer, and tokenizes the text with it to generate the .h5
+        file for training.
+        To make one of those things independently (e.g., only make the custom
+        tokenizer), see modules/tok_utils
+        """
+    )
+
+    parser.add_argument(
+        "--txt_path", "-t",
+        type=str,
+        required=True,
+        help="""The input file to be tokenized. This script will save the
+        following items:
+        - a folder of the same name as the containing folder of txt_path, with
+        '_h5' append. Example: 'code_dataset/input.txt -> code_dataset_h5/
+        - a tokenizer in modules/tokenizers called after the folder containing
+        the txt dataset. example: 'code_dataset/input.txt ->
+        modules/tokenizers/code_dataset_tokenizer/
+        """,
+    )
+
+    args = parser.parse_args()
+
+    txt_folder = os.path.split(args.txt_path)[0]
+
+    out_h5_folder = f"{txt_folder}_h5" #  Folder that will contain the output .h5 file
+    tokenizer_folder = "modules/tokenizers" # Folder where the tokenizer will be saved
+    tokenizer_name = f"{txt_folder}_tokenizer" # Name of the tokenizer that will be saved
 
     ################## DO NOT MODIFY BELOW ##################
-    txt_to_h5(txt_path, out_h5_folder, tokenizer_folder, tokenizer_name)
+    txt_to_h5(args.txt_path, out_h5_folder, tokenizer_folder, tokenizer_name)

--- a/train.py
+++ b/train.py
@@ -1,11 +1,24 @@
 """
     Base training function for language models. 
 """
-from modules import *
-import torch, torch.optim,os, argparse,json, pathlib,random, shutil
-from torch.utils.data import Subset
-from torchenhanced import CosineWarmup
+
+import os
+import json
+import shutil
+import pathlib
+
 import numpy as np
+
+import torch
+import torch.optim
+from torch.utils.data import Subset
+
+from modules import load_model
+from modules import load_trainer
+from modules import TokenTextBOS as TokenTextBOS
+from modules import get_tokenizer
+
+from torchenhanced import CosineWarmup
 
 
 def train(model_name : str, file_location : str, device : str | list[str], tokenizer_path : str ,
@@ -41,7 +54,7 @@ def train(model_name : str, file_location : str, device : str | list[str], token
             training_params = configo['training_params']
             optim_params = configo['optim_params']
     except Exception as e:
-        print(f'Error reading JSON file !')
+        print('Error reading JSON file !')
         raise(e)
 
     if not os.path.exists(training_params['dataset_folder']):
@@ -98,10 +111,10 @@ def train(model_name : str, file_location : str, device : str | list[str], token
     val_dataset = Subset(motherDataset, val_range)
 
     print('Datapoint example. Check it looks correct ! : ')
-    print(f'TRAIN DATA   :',tokenizer.detokenize(train_dataset[0][0][:20]))
-    print(f'TRAIN ANSWER : ',tokenizer.detokenize(train_dataset[0][1][:20]))
-    print(f'VALID DATA   :',tokenizer.detokenize(val_dataset[0][0][:20]))
-    print(f'VALID ANSWER : ',tokenizer.detokenize(val_dataset[0][1][:20]))
+    print('TRAIN DATA   :',tokenizer.detokenize(train_dataset[0][0][:20]))
+    print('TRAIN ANSWER : ',tokenizer.detokenize(train_dataset[0][1][:20]))
+    print('VALID DATA   :',tokenizer.detokenize(val_dataset[0][0][:20]))
+    print('VALID ANSWER : ',tokenizer.detokenize(val_dataset[0][1][:20]))
     
     model = load_model(model_name, model_params)
 
@@ -110,7 +123,7 @@ def train(model_name : str, file_location : str, device : str | list[str], token
     aggregate = training_params['aggregate']
     totbatches = len(train_dataset)//batch_size
     
-    if(training_params['steps_to_train']==None):
+    if(training_params['steps_to_train'] is None):
         steps_to_train = totbatches*4
     else:
         steps_to_train = training_params['steps_to_train']

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -8,8 +8,9 @@
     Note : uses wandb, so you need to have a wandb account and be logged in.
 """
 
-from train import train
 import argparse
+
+from train import train
 
 
 

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -1,11 +1,14 @@
 """
-    Training script for GPT-like models. Use this along with the output of gen_run !
+Training script for GPT-like models. Use this along with the output of gen_run!
 
-    Usage : python train_gpt.py <path_to_json_config_file> -d <device> -t <tokenizer_path> -p <project_name> -s
+Usage:
+    python train_gpt.py <path_to_json_config_file> -d <device> -t <tokenizer_path> -p <project_name> -s
 
-    Example : python train_gpt.py TrainParams/params.json -d cuda:0 -t fr -p BackPerplexityResilient -s
+Example:
+    python train_gpt.py TrainParams/params.json -d cuda:0 -t fr -p BackPerplexityResilient -s
 
-    Note : uses wandb, so you need to have a wandb account and be logged in.
+Note:
+    Uses wandb, so you need to have a wandb account and be logged in.
 """
 
 import argparse
@@ -20,7 +23,7 @@ if __name__=='__main__':
     parser.add_argument("-d", "--device", type=str, default='cpu', help="Device string, e.g. 'cuda:0' or 'cpu'")
     parser.add_argument("-t", "--tokenizer_path", type=str,help="Path for the tokenizer to use (only used for logging snippets). Relative to the train_script folder.")
     parser.add_argument("-p", "--project_name", help="Name of the project to log to. Default is 'BackPerplexityResilient'")
-    parser.add_argument("-s", "--no_step_pickup", action="store_false", help="If set, train steps_to_train steps more. Otherwise, will train UP TO steps_to_train TOTAL steps.")  
+    parser.add_argument("-s", "--no_step_pickup", action="store_false", help="If set, train steps_to_train steps more. Otherwise, will train UP TO steps_to_train TOTAL steps.")
     args = parser.parse_args()
 
     if(args.project_name is None):
@@ -28,5 +31,5 @@ if __name__=='__main__':
     else:
         project_name = args.project_name
 
-    train(model_name='gpt',file_location=args.file_location, device=args.device, tokenizer_path=args.tokenizer_path, 
+    train(model_name='gpt',file_location=args.file_location, device=args.device, tokenizer_path=args.tokenizer_path,
           project_name=project_name, step_pickup=args.no_step_pickup)

--- a/train_gru.py
+++ b/train_gru.py
@@ -1,11 +1,14 @@
 """
-    Training script for GRU-like models. Use this along with the output of gen_run !
+Training script for GRU-like models. Use this along with the output of gen_run!
 
-    Usage : python train_gru.py <path_to_json_config_file> -d <device> -t <tokenizer_path> -p <project_name> -s
+Usage:
+    python train_gru.py <path_to_json_config_file> -d <device> -t <tokenizer_path> -p <project_name> -s
 
-    Example : python train_gru.py TrainParams/params.json -d cuda:0 -t fr -p MyProject -s
+Example:
+    python train_gru.py TrainParams/params.json -d cuda:0 -t fr -p MyProject -s
 
-    Note : uses wandb, so you need to have a wandb account and be logged in.
+Note:
+    Uses wandb, so you need to have a wandb account and be logged in.
 """
 
 import argparse
@@ -18,7 +21,7 @@ if __name__=='__main__':
     parser.add_argument("-d", "--device", type=str, default='cpu', help="Device string, e.g. 'cuda:0' or 'cpu'")
     parser.add_argument("-t", "--tokenizer_path", type=str,help="Path for the tokenizer to use (only used for logging snippets). Relative to the train_script folder.")
     parser.add_argument("-p", "--project_name", help="Name of the project to log to. Default is 'CodePerplexity'")
-    parser.add_argument("-s", "--no_step_pickup", action="store_false", help="If set, train steps_to_train steps more. Otherwise, will train UP TO steps_to_train TOTAL steps.")  
+    parser.add_argument("-s", "--no_step_pickup", action="store_false", help="If set, train steps_to_train steps more. Otherwise, will train UP TO steps_to_train TOTAL steps.")
     args = parser.parse_args()
 
     if(args.project_name is None):
@@ -26,5 +29,5 @@ if __name__=='__main__':
     else:
         project_name = args.project_name
 
-    train(model_name='gru', file_location=args.file_location, device=args.device, tokenizer_path=args.tokenizer_path, 
+    train(model_name='gru', file_location=args.file_location, device=args.device, tokenizer_path=args.tokenizer_path,
           project_name=project_name, step_pickup=args.no_step_pickup)

--- a/train_gru.py
+++ b/train_gru.py
@@ -7,8 +7,9 @@
 
     Note : uses wandb, so you need to have a wandb account and be logged in.
 """
-from modules import *
+
 import argparse
+
 from train import train
 
 if __name__=='__main__':

--- a/train_lstm.py
+++ b/train_lstm.py
@@ -1,11 +1,15 @@
 """
-    Training script for LSTM-like models. Use this along with the output of gen_run !
+Training script for LSTM-like models. Use this along with the output of
+gen_run!
 
-    Usage : python train_lstm.py <path_to_json_config_file> -d <device> -t <tokenizer_path> -p <project_name> -s
+Usage:
+    python train_lstm.py <path_to_json_config_file> -d <device> -t <tokenizer_path> -p <project_name> -s
 
-    Example : python train_lstm.py TrainParams/params.json -d cuda:0 -t fr -p MyProject -s
+Example:
+    python train_lstm.py TrainParams/params.json -d cuda:0 -t fr -p MyProject -s
 
-    Note : uses wandb, so you need to have a wandb account and be logged in.
+Note:
+    Uses wandb, so you need to have a wandb account and be logged in.
 """
 
 import argparse
@@ -18,7 +22,7 @@ if __name__=='__main__':
     parser.add_argument("-d", "--device", type=str, default='cpu', help="Device string, e.g. 'cuda:0' or 'cpu'")
     parser.add_argument("-t", "--tokenizer_path", type=str,help="Path for the tokenizer to use (only used for logging snippets). Relative to the train_script folder.")
     parser.add_argument("-p", "--project_name", help="Name of the project to log to. Default is 'CodePerplexity'")
-    parser.add_argument("-s", "--no_step_pickup", action="store_false", help="If set, train steps_to_train steps more. Otherwise, will train UP TO steps_to_train TOTAL steps.")  
+    parser.add_argument("-s", "--no_step_pickup", action="store_false", help="If set, train steps_to_train steps more. Otherwise, will train UP TO steps_to_train TOTAL steps.")
     args = parser.parse_args()
 
     if(args.project_name is None):
@@ -26,5 +30,5 @@ if __name__=='__main__':
     else:
         project_name = args.project_name
 
-    train(model_name='lstm', file_location=args.file_location, device=args.device, tokenizer_path=args.tokenizer_path, 
+    train(model_name='lstm', file_location=args.file_location, device=args.device, tokenizer_path=args.tokenizer_path,
           project_name=project_name, step_pickup=args.no_step_pickup)

--- a/train_lstm.py
+++ b/train_lstm.py
@@ -7,8 +7,9 @@
 
     Note : uses wandb, so you need to have a wandb account and be logged in.
 """
-from modules import *
+
 import argparse
+
 from train import train
 
 if __name__=='__main__':

--- a/train_parallel.py
+++ b/train_parallel.py
@@ -8,9 +8,9 @@
     Note : uses wandb, so you need to have a wandb account and be logged in.
 """
 
-from train import train
 import argparse
 
+from train import train
 
 
 if __name__=='__main__':

--- a/train_parallel.py
+++ b/train_parallel.py
@@ -1,11 +1,15 @@
 """
-    Training script for GPT-like models in parallel. Implemented inefficiently, with torch.dataparallel.
+Training script for GPT-like models in parallel. Implemented inefficiently,
+with torch.dataparallel.
 
-    Usage : python train_gpt.py <path_to_json_config_file> -d <devices> -t <tokenizer_path> -p <project_name> -s
+Usage:
+    python train_gpt.py <path_to_json_config_file> -d <devices> -t <tokenizer_path> -p <project_name> -s
 
-    Example : python train_gpt.py TrainParams/params.json -d cuda:0 cuda:1 -t fr -p MyProject -s
+Example:
+    python train_gpt.py TrainParams/params.json -d cuda:0 cuda:1 -t fr -p MyProject -s
 
-    Note : uses wandb, so you need to have a wandb account and be logged in.
+Note:
+    Uses wandb, so you need to have a wandb account and be logged in.
 """
 
 import argparse
@@ -19,7 +23,7 @@ if __name__=='__main__':
     parser.add_argument('-d','--devices', nargs='+', help='A list of devices')
     parser.add_argument("-t", "--tokenizer_path", type=str,help="Path for the tokenizer to use (only used for logging snippets). Relative to the train_script folder.")
     parser.add_argument("-p", "--project_name", help="Name of the project to log to. Default is 'BackPerplexityResilient'")
-    parser.add_argument("-s", "--no_step_pickup", action="store_false", help="If set, train steps_to_train steps more. Otherwise, will train UP TO steps_to_train TOTAL steps.")  
+    parser.add_argument("-s", "--no_step_pickup", action="store_false", help="If set, train steps_to_train steps more. Otherwise, will train UP TO steps_to_train TOTAL steps.")
     args = parser.parse_args()
 
     if(args.project_name is None):
@@ -27,5 +31,5 @@ if __name__=='__main__':
     else:
         project_name = args.project_name
 
-    train(model_name='gpt',file_location=args.file_location, device=args.device, tokenizer_path=args.tokenizer_path, 
+    train(model_name='gpt',file_location=args.file_location, device=args.device, tokenizer_path=args.tokenizer_path,
           project_name=project_name, step_pickup=args.no_step_pickup)


### PR DESCRIPTION
- Paper-style readme
- Clearer directory structure when creating a new tokenizer: original file unchanged, split into `_pt`, then removed, and original text file name (instead of directory) used for `_h5`, as an option, otherwise defaults to `..._h5/dataset.h5`:

<img width="326" alt="Screenshot 2024-07-13 at 14 28 16" src="https://github.com/user-attachments/assets/27c42752-06d1-437d-921e-9e2dacc9137d">

- Disambiguation of all imports (no * any longer anywhere, one import per line): you might be able to test that I haven't introduced any bugs...
- Docstrings harmonisation