### PR TITLE
Argparse functionality, Ruff formatting, Readme deet

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ usage: tokenize_to_h5.py [-h] --txt_path TXT_PATH
         file for training.
 
         To make one of those things independently (e.g., only make the custom
-        tokenizer), see modules/tok_utils
+        tokenizer), see modules/tok_utils.
         
 
 options:
@@ -75,7 +75,7 @@ options:
                                                                my_dataset_pt/input_tokenized.pt
                                 2) a tokenizer in modules/tokenizers called after the folder containing
                                 the txt dataset. Example:
-                                    -t my_dataset/input.txt -> modules/tokenizers/code_dataset_tokenizer/
+                                    -t code_dataset/input.txt -> modules/tokenizers/code_dataset_tokenizer/
 ```
 
 Then run the script.
@@ -103,6 +103,8 @@ tokenized = toki.tokenize("Hello, world!") # Tokenize a string
 print(tokenized) # Get a tensor of ints shape [1, seq_len]
 print(toki.detokenize(tokenized)) # Detokenize a tensor of ints, prints "Hello, world!"
 ```
+
+Note: the scripts in `modules/tok_utils/` can, to some degree, be run independently, provided the path to the module folder is added to the PYTHONPATH: `PYTHONPATH="/path/to/modules:$PYTHONPATH" python modules/tok_utils/pt_to_h5.py --help`.
 
 ## Training
 

--- a/invert_text.py
+++ b/invert_text.py
@@ -1,5 +1,6 @@
 import argparse
 
+
 def reverse_file_line_by_line(input_file, output_file):
     """
     Reverse a large file line by line in text mode.
@@ -8,12 +9,12 @@ def reverse_file_line_by_line(input_file, output_file):
         input_file: Path to the input file.
         output_file: Path to the output file.
     """
-    with open(input_file, 'r', encoding='utf-8') as f_in:
+    with open(input_file, "r", encoding="utf-8") as f_in:
         f_in.seek(0, 2)  # Go to the end of the file
         position = f_in.tell()
-        current_line = ''
+        current_line = ""
 
-        with open(output_file, 'w', encoding='utf-8') as f_out:
+        with open(output_file, "w", encoding="utf-8") as f_out:
             while position >= 0:
                 f_in.seek(position)
                 try:
@@ -23,9 +24,9 @@ def reverse_file_line_by_line(input_file, output_file):
                     position -= 1
                     continue
 
-                if char == '\n':
-                    f_out.write(current_line[::-1] + '\n')
-                    current_line = ''
+                if char == "\n":
+                    f_out.write(current_line[::-1] + "\n")
+                    current_line = ""
                 else:
                     current_line = char + current_line
 
@@ -35,24 +36,16 @@ def reverse_file_line_by_line(input_file, output_file):
             if current_line:
                 f_out.write(current_line[::-1])
 
-if __name__ == "__main__":
 
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="""Reverse a large file line by line in text mode."""
     )
 
-    parser.add_argument(
-        "input_file", type=str,
-        help="""The input file path."""
-    )
+    parser.add_argument("input_file", type=str, help="""The input file path.""")
 
-    parser.add_argument(
-        "output_file", type=str,
-        help="""The output file path."""
-    )
+    parser.add_argument("output_file", type=str, help="""The output file path.""")
 
     args = parser.parse_args()
 
-    reverse_file_line_by_line(
-        args.input_file, args.output_file
-    )
+    reverse_file_line_by_line(args.input_file, args.output_file)

--- a/invert_text.py
+++ b/invert_text.py
@@ -1,9 +1,12 @@
+import argparse
+
 def reverse_file_line_by_line(input_file, output_file):
     """
     Reverse a large file line by line in text mode.
 
-    :param input_file: Path to the input file.
-    :param output_file: Path to the output file.
+    Args:
+        input_file: Path to the input file.
+        output_file: Path to the output file.
     """
     with open(input_file, 'r', encoding='utf-8') as f_in:
         f_in.seek(0, 2)  # Go to the end of the file
@@ -32,5 +35,24 @@ def reverse_file_line_by_line(input_file, output_file):
             if current_line:
                 f_out.write(current_line[::-1])
 
-# USAGE
-reverse_file_line_by_line('jeff.txt', 'jeff_R.txt')
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        description="""Reverse a large file line by line in text mode."""
+    )
+
+    parser.add_argument(
+        "input_file", type=str,
+        help="""The input file path."""
+    )
+
+    parser.add_argument(
+        "output_file", type=str,
+        help="""The output file path."""
+    )
+
+    args = parser.parse_args()
+
+    reverse_file_line_by_line(
+        args.input_file, args.output_file
+    )

--- a/modules/datasets/TokenText.py
+++ b/modules/datasets/TokenText.py
@@ -1,6 +1,5 @@
 import os
 import h5py
-import numpy as np
 
 import torch
 from torch.utils.data import Dataset

--- a/modules/datasets/TokenText.py
+++ b/modules/datasets/TokenText.py
@@ -8,124 +8,154 @@ from torch.utils.data import Dataset
 
 class TokenTexth5(Dataset):
     """
-        Dataset used to store tokenized text. Produces tuples of text, and the text shifted by one
-        token, to be used as input and target for language modelling. Uses memory mapping, with hdf5.
+    Dataset used to store tokenized text. Produces tuples of text, and the text shifted by one
+    token, to be used as input and target for language modelling. Uses memory mapping, with hdf5.
 
-        If we notice that creation of the data is SLOW, we may use batched calls like I did the the cellular automata, to be seen.
-        Args:
-        text_location : location of the tokenized text tensor
-        attn_length : size of the attention window
-        stride : by how many tokens to stride to get the next example. Default is half the attention length.
+    If we notice that creation of the data is SLOW, we may use batched calls like I did the the cellular automata, to be seen.
+    Args:
+    text_location : location of the tokenized text tensor
+    attn_length : size of the attention window
+    stride : by how many tokens to stride to get the next example. Default is half the attention length.
     """
 
-    def __init__(self,h5_file :str, attn_length:int, stride:int=None, backwards=False):
+    def __init__(
+        self, h5_file: str, attn_length: int, stride: int = None, backwards=False
+    ):
         self.h5_file = h5_file
         self.attn_length = attn_length
 
         self.backwards = backwards
 
-
-        if(stride is None):
-            self.stride=self.attn_length//2
-        else :
+        if stride is None:
+            self.stride = self.attn_length // 2
+        else:
             self.stride = stride
 
-        if(not os.path.isfile(self.h5_file)):
-            raise ValueError(f'File/Folder {self.h5_file} not found')
+        if not os.path.isfile(self.h5_file):
+            raise ValueError(f"File/Folder {self.h5_file} not found")
 
-        self.h5_file = h5py.File(self.h5_file, 'r')
-        self.text_tensor = self.h5_file['tokens']
-
+        self.h5_file = h5py.File(self.h5_file, "r")
+        self.text_tensor = self.h5_file["tokens"]
 
         self.num_tokens = len(self.text_tensor)
-        self.length = (self.num_tokens-self.attn_length-1)//(self.stride) # -1 because we need to have a target for each input
+        # -1 because we need to have a target for each input
+        self.length = (self.num_tokens - self.attn_length - 1) // self.stride
 
-        print(f'Dataset contains {self.num_tokens/1e6:.2f}M tokens, resulting in {self.length//1000}k examples.')
+        print(
+            f"Dataset contains {self.num_tokens/1e6:.2f}M tokens, resulting in {self.length//1000}k examples."
+        )
 
     def __len__(self):
         return self.length
 
     def __getitem__(self, idx):
         """
-            Returns a tuple of (input, target) tensors, each of shape (attn_length)
+        Returns a tuple of (input, target) tensors, each of shape (attn_length)
 
-            For now, when backwards, we still give the examples in the 'forward' way, but
-            we flip them. Maybe there is some reason why this is no bueno, but I don't think so.
+        For now, when backwards, we still give the examples in the 'forward' way, but
+        we flip them. Maybe there is some reason why this is no bueno, but I don't think so.
         """
-        true_idx = self.stride*(idx)
+        true_idx = self.stride * (idx)
 
-        if(self.backwards):
-            return torch.tensor(self.text_tensor[true_idx+1:true_idx+self.attn_length+1],dtype=torch.long).flip(dims=(0,)), \
-                torch.tensor(self.text_tensor[true_idx:true_idx+self.attn_length],dtype=torch.long).flip(dims=(0,))
-        else :
-            true_idx = idx*self.stride
-            return torch.tensor(self.text_tensor[true_idx:true_idx+self.attn_length],dtype=torch.long), \
-            torch.tensor(self.text_tensor[true_idx+1:true_idx+self.attn_length+1],dtype=torch.long)
+        if self.backwards:
+            return torch.tensor(
+                self.text_tensor[true_idx + 1 : true_idx + self.attn_length + 1],
+                dtype=torch.long,
+            ).flip(dims=(0,)), torch.tensor(
+                self.text_tensor[true_idx : true_idx + self.attn_length],
+                dtype=torch.long,
+            ).flip(dims=(0,))
+        else:
+            true_idx = idx * self.stride
+            return torch.tensor(
+                self.text_tensor[true_idx : true_idx + self.attn_length],
+                dtype=torch.long,
+            ), torch.tensor(
+                self.text_tensor[true_idx + 1 : true_idx + self.attn_length + 1],
+                dtype=torch.long,
+            )
 
 
 class TokenTextBOS(Dataset):
     """
-        Dataset used to store tokenized text. Produces tuples of text, and the text shifted by one
-        token, to be used as input and target for language modelling. Uses memory mapping, with hdf5.
-        Adds a BOS token at the beginning, such that we don't 'miss' any token. As such, the 'effective'
-        attention length is one less, as one token is dedicated to the <BOS> token.
+    Dataset used to store tokenized text. Produces tuples of text, and the text shifted by one
+    token, to be used as input and target for language modelling. Uses memory mapping, with hdf5.
+    Adds a BOS token at the beginning, such that we don't 'miss' any token. As such, the 'effective'
+    attention length is one less, as one token is dedicated to the <BOS> token.
 
-        Args:
-        text_location : location of the tokenized text tensor
-        attn_length : size of the attention window TO BE CHANGED; IT IS ACTUALLY THE NUMBER OF TOKENS, NOT INCLUDE BOS
-        stride : by how many tokens to stride to get the next example. Default is half the attention length.
-        vocab_size : vocabulary_size such that we can add a BOS token at the beginning which will be vocab_size+1
+    Args:
+    text_location : location of the tokenized text tensor
+    attn_length : size of the attention window TO BE CHANGED; IT IS ACTUALLY THE NUMBER OF TOKENS, NOT INCLUDE BOS
+    stride : by how many tokens to stride to get the next example. Default is half the attention length.
+    vocab_size : vocabulary_size such that we can add a BOS token at the beginning which will be vocab_size+1
     """
 
-    def __init__(self,h5_file :str, attn_length:int, stride:int=None, backwards=False):
+    def __init__(
+        self, h5_file: str, attn_length: int, stride: int = None, backwards=False
+    ):
         self.h5_file = h5_file
-        self.attn_length = attn_length-1 # -1 because we add a BOS token
+        self.attn_length = attn_length - 1  # -1 because we add a BOS token
         # attn_length is actually the length of the text that is produced. Adding the BOS, we get sentences of length attn_length+1
         self.backwards = backwards
 
-
-        if(stride is None):
-            self.stride=self.attn_length//2
-        else :
+        if stride is None:
+            self.stride = self.attn_length // 2
+        else:
             self.stride = stride
 
-        if(not os.path.isfile(self.h5_file)):
-            raise ValueError(f'File/Folder {self.h5_file} not found')
+        if not os.path.isfile(self.h5_file):
+            raise ValueError(f"File/Folder {self.h5_file} not found")
 
-        self.h5_file = h5py.File(self.h5_file, 'r')
-        self.text_tensor = self.h5_file['tokens']
-
+        self.h5_file = h5py.File(self.h5_file, "r")
+        self.text_tensor = self.h5_file["tokens"]
 
         self.num_tokens = len(self.text_tensor)
-        self.length = (self.num_tokens-self.attn_length-1)//(self.stride) # -1 because we need to have a target for each input
+        # -1 because we need to have a target for each input
+        self.length = (self.num_tokens - self.attn_length - 1) // (self.stride)
 
-        print(f'Dataset contains {self.num_tokens/1e6:.2f}M tokens, resulting in {self.length//1000}k examples.')
+        print(
+            f"Dataset contains {self.num_tokens/1e6:.2f}M tokens, resulting in {self.length//1000}k examples."
+        )
 
     def __len__(self):
         return self.length
 
     def __getitem__(self, idx):
         """
-            Returns a tuple of (input, target) tensors, each of shape (attn_length)
+        Returns a tuple of (input, target) tensors, each of shape (attn_length)
 
-            For now, when backwards, we still give the examples in the 'forward' way, but
-            we flip them. Maybe there is some reason why this is no bueno, but I don't think so.
+        For now, when backwards, we still give the examples in the 'forward' way, but
+        we flip them. Maybe there is some reason why this is no bueno, but I don't think so.
         """
-        true_idx = self.stride*(idx)
+        true_idx = self.stride * (idx)
 
-        if(self.backwards):
-            return self.add_BOS(torch.tensor(self.text_tensor[true_idx+1:true_idx+self.attn_length+1],dtype=torch.long).flip(dims=(0,))), \
-                torch.tensor(self.text_tensor[true_idx:true_idx+self.attn_length+1],dtype=torch.long).flip(dims=(0,))
-        else :
-            return self.add_BOS(torch.tensor(self.text_tensor[true_idx:true_idx+self.attn_length],dtype=torch.long)), \
-            torch.tensor(self.text_tensor[true_idx:true_idx+self.attn_length+1],dtype=torch.long)
+        if self.backwards:
+            return self.add_BOS(
+                torch.tensor(
+                    self.text_tensor[true_idx + 1 : true_idx + self.attn_length + 1],
+                    dtype=torch.long,
+                ).flip(dims=(0,))
+            ), torch.tensor(
+                self.text_tensor[true_idx : true_idx + self.attn_length + 1],
+                dtype=torch.long,
+            ).flip(dims=(0,))
+        else:
+            return self.add_BOS(
+                torch.tensor(
+                    self.text_tensor[true_idx : true_idx + self.attn_length],
+                    dtype=torch.long,
+                )
+            ), torch.tensor(
+                self.text_tensor[true_idx : true_idx + self.attn_length + 1],
+                dtype=torch.long,
+            )
 
-    def add_BOS(self,tens):
+    def add_BOS(self, tens):
         """
-            Adds a BOS token at the beginning of the tensor, and returns it.
+        Adds a BOS token at the beginning of the tensor, and returns it.
 
-            Args:
-            tens : tensor of shape (attn_length)
+        Args:
+        tens : tensor of shape (attn_length)
         """
-        return torch.cat([torch.tensor([0],dtype=torch.long),tens],dim=0) # (attn_length+1)
-
+        # (attn_length+1)
+        return torch.cat([torch.tensor([0], dtype=torch.long), tens], dim=0)

--- a/modules/models/gru/MinGRU.py
+++ b/modules/models/gru/MinGRU.py
@@ -26,32 +26,52 @@ class MinGRU(ConfigModule):
         embd_dropout: (optional) dropout probability for the embedding layer
     """
 
-    def __init__(self, vocab_size:int,embed_dim :int, desired_attn_length:int, n_layers:int=1,
-                 dropout:float=0.1, embd_dropout:float=None):
-        configo = dict(vocab_size=vocab_size,n_layers=n_layers,embed_dim=embed_dim,
-                       desired_attn_length=desired_attn_length,dropout=dropout,embd_dropout=embd_dropout)
+    def __init__(
+        self,
+        vocab_size: int,
+        embed_dim: int,
+        desired_attn_length: int,
+        n_layers: int = 1,
+        dropout: float = 0.1,
+        embd_dropout: float = None,
+    ):
+        configo = dict(
+            vocab_size=vocab_size,
+            n_layers=n_layers,
+            embed_dim=embed_dim,
+            desired_attn_length=desired_attn_length,
+            dropout=dropout,
+            embd_dropout=embd_dropout,
+        )
 
         super().__init__(configo)
 
-        if(embd_dropout is None):
+        if embd_dropout is None:
             embd_dropout = dropout
 
-
-        self.gru = nn.GRU(input_size=embed_dim, hidden_size=embed_dim, num_layers=n_layers,batch_first=True,dropout=dropout,
-                          bidirectional=False)
+        self.gru = nn.GRU(
+            input_size=embed_dim,
+            hidden_size=embed_dim,
+            num_layers=n_layers,
+            batch_first=True,
+            dropout=dropout,
+            bidirectional=False,
+        )
 
         self.token_embedder = nn.Embedding(vocab_size, embed_dim)
         self.embd_dropout = nn.Dropout(embd_dropout)
-
 
         self.ln_f = nn.LayerNorm(embed_dim)
         self.lm_head = nn.Linear(embed_dim, vocab_size, bias=False)
 
         print(f'{"gru :"}'.capitalize())
-        print("number of parameters: %.2fM" % (self.paranum/1e6,))
-        print("Without head : %.2fM" % ((self.paranum-sum(p.numel() for p in self.lm_head.parameters()))/1e6))
+        print("number of parameters: %.2fM" % (self.paranum / 1e6,))
+        print(
+            "Without head : %.2fM"
+            % ((self.paranum - sum(p.numel() for p in self.lm_head.parameters())) / 1e6)
+        )
 
-    def forward(self, idx)-> torch.Tensor:
+    def forward(self, idx) -> torch.Tensor:
         """
         Process sequence of digits and outputs logits
 
@@ -66,22 +86,28 @@ class MinGRU(ConfigModule):
         # assert T <= self.attn_length, f"Cannot forward sequence of length {T}, block size is only {self.attn_length}"
 
         # forward the GPT model
-        idx = self.embd_dropout(self.token_embedder(idx)) # token embeddings of shape (B, T, n_embd)
+        # token embeddings of shape (B, T, n_embd)
+        idx = self.embd_dropout(self.token_embedder(idx))
 
+        idx, hf = self.gru(idx)  # (B,T,n_embd) (use default zeros for h0)
 
-        idx, hf =self.gru(idx) # (B,T,n_embd) (use default zeros for h0)
-
-        assert hf.shape == (self.config['n_layers'],B,self.config['embed_dim']), f"hf shape \
+        assert hf.shape == (
+            self.config["n_layers"],
+            B,
+            self.config["embed_dim"],
+        ), f"hf shape \
           is wrong : {hf.shape} ! it does batch_first=True, when it shouldn't !!"
 
-        idx = self.ln_f(idx) # Still (B,T,n_embd)
+        idx = self.ln_f(idx)  # Still (B,T,n_embd)
 
-        logits = self.lm_head(idx) # (B,T,vocab_size) logits
+        logits = self.lm_head(idx)  # (B,T,vocab_size) logits
 
-        return logits # (B,T,vocab_size)
+        return logits  # (B,T,vocab_size)
 
     @torch.no_grad()
-    def generate(self, idx, max_new_tokens, temperature=1.0, do_sample=False, top_k=None):
+    def generate(
+        self, idx, max_new_tokens, temperature=1.0, do_sample=False, top_k=None
+    ):
         """
         Take a conditioning sequence of indices idx (LongTensor of shape (B,T))
         and complete the sequence max_new_tokens times, feeding the predictions
@@ -104,22 +130,26 @@ class MinGRU(ConfigModule):
             (B,T) LongTensor of generated token indices. Must still be decoded by tokenizer.
         """
         B, T = idx.shape
-        last_tok = (idx[:,-1])[:,None]# (B,1)
+        last_tok = (idx[:, -1])[:, None]  # (B,1)
 
         # First, run the context through the GRU :
-        context = self.token_embedder(idx[:,:-1]) # (B,T-1,n_embd)
-        _, hf = self.gru(context) # (n_layers,B,n_embd) (use default zeros for h0)
+        context = self.token_embedder(idx[:, :-1])  # (B,T-1,n_embd)
+        _, hf = self.gru(context)  # (n_layers,B,n_embd) (use default zeros for h0)
 
         # Then, generate, giving only last hf and last token as input, for speed :
         for _ in range(max_new_tokens):
-            last_tok,hf = self.generate_next_token(last_tok,hf,temperature=temperature,do_sample=do_sample,top_k=top_k)
+            last_tok, hf = self.generate_next_token(
+                last_tok, hf, temperature=temperature, do_sample=do_sample, top_k=top_k
+            )
 
             idx = torch.cat((idx, last_tok), dim=1)
 
         return idx
 
     @torch.no_grad()
-    def generate_next_token(self,idx, hidden,temperature=1.0, do_sample=False, top_k=None):
+    def generate_next_token(
+        self, idx, hidden, temperature=1.0, do_sample=False, top_k=None
+    ):
         """
         Take a condition hidden state and and token index and generates the
         next token.
@@ -139,32 +169,31 @@ class MinGRU(ConfigModule):
         Returns:
             (next predicted token, (B,1) longs), (last hidden state (n_layers,B,n_embd))
         """
-        idx=self.token_embedder(idx) # (B,1,n_embd)
+        idx = self.token_embedder(idx)  # (B,1,n_embd)
         # forward the model to get the logits for the index in the sequence
-        out, hf = self.gru(idx,hidden) # (B,1,n_embd) (1,B,n_embd)
+        out, hf = self.gru(idx, hidden)  # (B,1,n_embd) (1,B,n_embd)
 
-        logits = self.lm_head(self.ln_f(out)) # (B,1,vsize)
+        logits = self.lm_head(self.ln_f(out))  # (B,1,vsize)
 
         # pluck the logits at the final step and scale by desired temperature
         logits = logits[:, -1, :] / temperature
         # optionally crop the logits to only the top k options
         if top_k is not None:
             v, _ = torch.topk(logits, top_k)
-            logits[logits < v[:, [-1]]] = -float('Inf')
+            logits[logits < v[:, [-1]]] = -float("Inf")
         # apply softmax to convert logits to (normalized) probabilities
         probs = F.softmax(logits, dim=-1)
 
         # either sample from the distribution or take the most likely element
         if do_sample:
-            idx_next = torch.multinomial(probs, num_samples=1) # (B,1)
+            idx_next = torch.multinomial(probs, num_samples=1)  # (B,1)
         else:
-            _, idx_next = torch.topk(probs, k=1, dim=-1) # (B,1)
+            _, idx_next = torch.topk(probs, k=1, dim=-1)  # (B,1)
 
         return idx_next, hf
 
 
 class MinLSTM(ConfigModule):
-
     """
     Simple LSTM for language modeling.
 
@@ -178,32 +207,52 @@ class MinLSTM(ConfigModule):
         embd_dropout: (optional) dropout probability for the embedding layer
     """
 
-    def __init__(self, vocab_size:int,embed_dim :int, desired_attn_length:int, n_layers:int=1,
-                 dropout:float=0.1, embd_dropout:float=None):
-        configo = dict(vocab_size=vocab_size,n_layers=n_layers,embed_dim=embed_dim,
-                       desired_attn_length=desired_attn_length,dropout=dropout,embd_dropout=embd_dropout)
+    def __init__(
+        self,
+        vocab_size: int,
+        embed_dim: int,
+        desired_attn_length: int,
+        n_layers: int = 1,
+        dropout: float = 0.1,
+        embd_dropout: float = None,
+    ):
+        configo = dict(
+            vocab_size=vocab_size,
+            n_layers=n_layers,
+            embed_dim=embed_dim,
+            desired_attn_length=desired_attn_length,
+            dropout=dropout,
+            embd_dropout=embd_dropout,
+        )
 
         super().__init__(configo)
 
-        if(embd_dropout is None):
+        if embd_dropout is None:
             embd_dropout = dropout
 
-
-        self.lstm= nn.LSTM(input_size=embed_dim, hidden_size=embed_dim, num_layers=n_layers,batch_first=True,dropout=dropout,
-                          bidirectional=False)
+        self.lstm = nn.LSTM(
+            input_size=embed_dim,
+            hidden_size=embed_dim,
+            num_layers=n_layers,
+            batch_first=True,
+            dropout=dropout,
+            bidirectional=False,
+        )
 
         self.token_embedder = nn.Embedding(vocab_size, embed_dim)
         self.embd_dropout = nn.Dropout(embd_dropout)
-
 
         self.ln_f = nn.LayerNorm(embed_dim)
         self.lm_head = nn.Linear(embed_dim, vocab_size, bias=False)
 
         print(f'{"lstm:"}'.capitalize())
-        print("number of parameters: %.2fM" % (self.paranum/1e6,))
-        print("Without head : %.2fM" % ((self.paranum-sum(p.numel() for p in self.lm_head.parameters()))/1e6))
+        print("number of parameters: %.2fM" % (self.paranum / 1e6,))
+        print(
+            "Without head : %.2fM"
+            % ((self.paranum - sum(p.numel() for p in self.lm_head.parameters())) / 1e6)
+        )
 
-    def forward(self, idx)-> torch.Tensor:
+    def forward(self, idx) -> torch.Tensor:
         """
         Process sequence of digits and outputs logits
 
@@ -218,22 +267,31 @@ class MinLSTM(ConfigModule):
         # assert T <= self.attn_length, f"Cannot forward sequence of length {T}, block size is only {self.attn_length}"
 
         # forward the GPT model
-        idx = self.embd_dropout(self.token_embedder(idx)) # token embeddings of shape (B, T, n_embd)
+        idx = self.embd_dropout(
+            self.token_embedder(idx)
+        )  # token embeddings of shape (B, T, n_embd)
 
+        idx, (hf, cf) = self.lstm(idx)  # (B,T,n_embd) (use default zeros for h0)
 
-        idx, (hf,cf) =self.lstm(idx) # (B,T,n_embd) (use default zeros for h0)
+        assert (
+            hf.shape
+            == (
+                self.config["n_layers"],
+                B,
+                self.config["embed_dim"],
+            )
+        ), f"hf shape  is wrong : {hf.shape} ! it does batch_first=True, when it shouldn't !!"
 
-        assert hf.shape == (self.config['n_layers'],B,self.config['embed_dim']), f"hf shape \
-          is wrong : {hf.shape} ! it does batch_first=True, when it shouldn't !!"
+        idx = self.ln_f(idx)  # Still (B,T,n_embd)
 
-        idx = self.ln_f(idx) # Still (B,T,n_embd)
+        logits = self.lm_head(idx)  # (B,T,vocab_size) logits
 
-        logits = self.lm_head(idx) # (B,T,vocab_size) logits
-
-        return logits # (B,T,vocab_size)
+        return logits  # (B,T,vocab_size)
 
     @torch.no_grad()
-    def generate(self, idx, max_new_tokens, temperature=1.0, do_sample=False, top_k=None):
+    def generate(
+        self, idx, max_new_tokens, temperature=1.0, do_sample=False, top_k=None
+    ):
         """
         Take a conditioning sequence of indices idx (LongTensor of shape (B,T))
         and complete the sequence max_new_tokens times, feeding the predictions
@@ -256,22 +314,31 @@ class MinLSTM(ConfigModule):
             (B,T) LongTensor of generated token indices. Must still be decoded by tokenizer.
         """
         B, T = idx.shape
-        last_tok = (idx[:,-1])[:,None]# (B,1)
+        last_tok = (idx[:, -1])[:, None]  # (B,1)
 
         # First, run the context through the GRU :
-        context = self.token_embedder(idx[:,:-1]) # (B,T-1,n_embd)
-        _, (hf,cf) = self.lstm(context) # (n_layers,B,n_embd) (use default zeros for h0)
+        context = self.token_embedder(idx[:, :-1])  # (B,T-1,n_embd)
+        # (n_layers,B,n_embd) (use default zeros for h0)
+        _, (hf, cf) = self.lstm(context)
 
         # Then, generate, giving only last hf and last token as input, for speed :
         for _ in range(max_new_tokens):
-            last_tok,(hf,cf) = self.generate_next_token(last_tok,(hf,cf),temperature=temperature,do_sample=do_sample,top_k=top_k)
+            last_tok, (hf, cf) = self.generate_next_token(
+                last_tok,
+                (hf, cf),
+                temperature=temperature,
+                do_sample=do_sample,
+                top_k=top_k,
+            )
 
             idx = torch.cat((idx, last_tok), dim=1)
 
         return idx
 
     @torch.no_grad()
-    def generate_next_token(self,idx, hidden,temperature=1.0, do_sample=False, top_k=None):
+    def generate_next_token(
+        self, idx, hidden, temperature=1.0, do_sample=False, top_k=None
+    ):
         """
         Take a condition hidden state and and token index and generates the
         next token.
@@ -290,25 +357,25 @@ class MinLSTM(ConfigModule):
         Returns:
             (next predicted token, (B,1) longs), (last hidden state (n_layers,B,n_embd))
         """
-        idx=self.token_embedder(idx) # (B,1,n_embd)
+        idx = self.token_embedder(idx)  # (B,1,n_embd)
         # forward the model to get the logits for the index in the sequence
-        out, (hf,cf) = self.lstm(idx,hidden) # (B,1,n_embd) (1,B,n_embd)
+        out, (hf, cf) = self.lstm(idx, hidden)  # (B,1,n_embd) (1,B,n_embd)
 
-        logits = self.lm_head(self.ln_f(out)) # (B,1,vsize)
+        logits = self.lm_head(self.ln_f(out))  # (B,1,vsize)
 
         # pluck the logits at the final step and scale by desired temperature
         logits = logits[:, -1, :] / temperature
         # optionally crop the logits to only the top k options
         if top_k is not None:
             v, _ = torch.topk(logits, top_k)
-            logits[logits < v[:, [-1]]] = -float('Inf')
+            logits[logits < v[:, [-1]]] = -float("Inf")
         # apply softmax to convert logits to (normalized) probabilities
         probs = F.softmax(logits, dim=-1)
 
         # either sample from the distribution or take the most likely element
         if do_sample:
-            idx_next = torch.multinomial(probs, num_samples=1) # (B,1)
+            idx_next = torch.multinomial(probs, num_samples=1)  # (B,1)
         else:
-            _, idx_next = torch.topk(probs, k=1, dim=-1) # (B,1)
+            _, idx_next = torch.topk(probs, k=1, dim=-1)  # (B,1)
 
-        return idx_next, (hf,cf)
+        return idx_next, (hf, cf)

--- a/modules/models/gru/MinGRU.py
+++ b/modules/models/gru/MinGRU.py
@@ -2,13 +2,10 @@
 Full definition of a GPT Language Model.
 """
 
-import math
-
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
 
-from torchenhanced import DevModule
 from torchenhanced import ConfigModule
 
 

--- a/modules/models/gru/MinGRU_Trainer.py
+++ b/modules/models/gru/MinGRU_Trainer.py
@@ -16,30 +16,63 @@ from ...tokenizer import Tokenizer
 
 
 class MinGRU_Trainer(Trainer):
-    def __init__(self, model: MinGRU, train_dataset: TokenText, valid_dataset : TokenText, backwards : bool=True,
-                 detokenizer :Tokenizer=None, optim: Optimizer = None, scheduler: _LRScheduler = None,
-                 state_save_loc=None, device: str = 'cpu',parallel=None, run_name: str = None, project_name: str = None,
-                 run_config: dict ={}):
-        super().__init__(model, optim, scheduler, state_save_loc=state_save_loc, device=device, parallel=parallel,
-                         run_name=run_name, project_name=project_name, run_config=run_config)
+    def __init__(
+        self,
+        model: MinGRU,
+        train_dataset: TokenText,
+        valid_dataset: TokenText,
+        backwards: bool = True,
+        detokenizer: Tokenizer = None,
+        optim: Optimizer = None,
+        scheduler: _LRScheduler = None,
+        state_save_loc=None,
+        device: str = "cpu",
+        parallel=None,
+        run_name: str = None,
+        project_name: str = None,
+        run_config: dict = {},
+    ):
+        super().__init__(
+            model,
+            optim,
+            scheduler,
+            state_save_loc=state_save_loc,
+            device=device,
+            parallel=parallel,
+            run_name=run_name,
+            project_name=project_name,
+            run_config=run_config,
+        )
 
         self.train_dataset = train_dataset
         self.valid_dataset = valid_dataset
         # For logging :
         self.batch_loss = []
 
-        self.detokenizer= detokenizer
+        self.detokenizer = detokenizer
 
-        self.backwards = backwards # In principle, extractable form dataset, but annoying because I use Subset, so I just give it.
+        self.backwards = backwards  # In principle, extractable form dataset, but annoying because I use Subset, so I just give it.
 
         # Print number of parameters
-        print(f"Number of parameters : {sum(p.numel() for p in self.model.parameters())/1e6:.2f}M")
+        print(
+            f"Number of parameters : {sum(p.numel() for p in self.model.parameters())/1e6:.2f}M"
+        )
 
-    def get_loaders(self,batch_size,num_workers=0):
-        t_dataloader = DataLoader(self.train_dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers)
-        v_dataloader = DataLoader(self.valid_dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers)
+    def get_loaders(self, batch_size, num_workers=0):
+        t_dataloader = DataLoader(
+            self.train_dataset,
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=num_workers,
+        )
+        v_dataloader = DataLoader(
+            self.valid_dataset,
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=num_workers,
+        )
 
-        self.text_table = wandb.Table(columns=["batches","text"])
+        self.text_table = wandb.Table(columns=["batches", "text"])
 
         return t_dataloader, v_dataloader
 
@@ -47,24 +80,24 @@ class MinGRU_Trainer(Trainer):
         # Check if correct, but should be :
         loss = self.compute_loss(batch_data)
 
-        if(self.do_batch_log) :
-            wandb.log({'lr' : self.scheduler.get_last_lr()[0]},commit=False)
+        if self.do_batch_log:
+            wandb.log({"lr": self.scheduler.get_last_lr()[0]}, commit=False)
 
         return loss
 
     def compute_loss(self, batch_data):
         token_in, token_truth = batch_data
-        B,T = token_truth.shape
+        B, T = token_truth.shape
 
         token_in = token_in.to(self.device)
-        token_truth = token_truth.to(self.device) # (B, T)
+        token_truth = token_truth.to(self.device)  # (B, T)
 
         token_in = self.model.forward(token_in)
         # RESHAPE OTHERWISE, CROSS ENTROPY LOSS BUGS FOR BIG BATCHES
-        token_in = token_in.reshape(B*T,-1) # (B*T, C)
-        token_truth = token_truth.reshape(B*T)
+        token_in = token_in.reshape(B * T, -1)  # (B*T, C)
+        token_truth = token_truth.reshape(B * T)
         # Check if correct, but should be :
-        loss = F.cross_entropy(token_in,token_truth,reduction='mean')
+        loss = F.cross_entropy(token_in, token_truth, reduction="mean")
 
         return loss
 
@@ -74,22 +107,27 @@ class MinGRU_Trainer(Trainer):
 
         return loss
 
-
     def valid_log(self):
-        #To be implemented when doing validation
-        data, _ = self.valid_dataset[random.randint(0,len(self.valid_dataset)-1)] # (T,)*2
-        data = data[:5].to(self.device) # only keep first 5 tokens
+        # To be implemented when doing validation
+        data, _ = self.valid_dataset[
+            random.randint(0, len(self.valid_dataset) - 1)
+        ]  # (T,)*2
+        data = data[:5].to(self.device)  # only keep first 5 tokens
 
-        phrase_out = self.model.generate(data[None,:],max_new_tokens=100, do_sample=True).cpu() # (1, 5+300)
+        phrase_out = self.model.generate(
+            data[None, :], max_new_tokens=100, do_sample=True
+        ).cpu()  # (1, 5+300)
 
-        if(self.backwards):
-            phrase_out= self.detokenizer.detokenize(torch.flip(phrase_out,dims=[1])) # ()
-        else :
-            phrase_out=self.detokenizer.detokenize(phrase_out)
+        if self.backwards:
+            phrase_out = self.detokenizer.detokenize(
+                torch.flip(phrase_out, dims=[1])
+            )  # ()
+        else:
+            phrase_out = self.detokenizer.detokenize(phrase_out)
 
-        self.text_table.add_data(f"{self.steps_done/1000:.1f}k",phrase_out)
+        self.text_table.add_data(f"{self.steps_done/1000:.1f}k", phrase_out)
         # Trick to be able to update table on the fly... Fucking wandb
         new_table = wandb.Table(
-        columns=self.text_table.columns, data=self.text_table.data
+            columns=self.text_table.columns, data=self.text_table.data
         )
-        wandb.log({'gen_samples': new_table},commit=False)
+        wandb.log({"gen_samples": new_table}, commit=False)

--- a/modules/models/load_model.py
+++ b/modules/models/load_model.py
@@ -5,19 +5,25 @@ from .gru import MinGRU_Trainer
 from .mingpt import MinGPT
 from .mingpt import MinGPT_Trainer
 
-def load_model(model_name:str, model_config:dict):
+
+def load_model(model_name: str, model_config: dict):
     """
     Loads and return model.
 
     Args:
         model_name: name of the model to load. 'gru','lstm' or 'gpt'
     """
-    model_dict= {'gru':MinGRU,'lstm':MinLSTM,'gpt':MinGPT}
-    assert model_name.lower() in ['gru','lstm','gpt'], 'Model name should be one of "gru","lstm" or "gpt"'
+    model_dict = {"gru": MinGRU, "lstm": MinLSTM, "gpt": MinGPT}
+    assert model_name.lower() in [
+        "gru",
+        "lstm",
+        "gpt",
+    ], 'Model name should be one of "gru","lstm" or "gpt"'
 
     return model_dict[model_name.lower()](**model_config)
 
-def load_trainer(model_name: str, trainer_config:dict):
+
+def load_trainer(model_name: str, trainer_config: dict):
     """
     Loads and return trainer.
 
@@ -26,8 +32,16 @@ def load_trainer(model_name: str, trainer_config:dict):
         trainer_config: dict of parameters to the trainer
     """
 
-    trainer_dict = {'gru':MinGRU_Trainer,'lstm':MinGRU_Trainer,'gpt':MinGPT_Trainer}
+    trainer_dict = {
+        "gru": MinGRU_Trainer,
+        "lstm": MinGRU_Trainer,
+        "gpt": MinGPT_Trainer,
+    }
 
-    assert model_name.lower() in ['gru','lstm','gpt'], 'Model name should be one of "gru","lstm" or "gpt"'
+    assert model_name.lower() in [
+        "gru",
+        "lstm",
+        "gpt",
+    ], 'Model name should be one of "gru","lstm" or "gpt"'
 
     return trainer_dict[model_name.lower()](**trainer_config)

--- a/modules/models/mingpt/MinGPT.py
+++ b/modules/models/mingpt/MinGPT.py
@@ -35,8 +35,17 @@ class MinGPT(ConfigModule):
     'gpt-nano':     n_layer=3, n_head=3, n_embd=48,
     """
 
-    def __init__(self, vocab_size:int,n_layers:int,embed_dim :int, n_heads:int,attn_length:int,
-                 mlp_ratio:float=4,dropout:float=0.1, embd_dropout:float=None):
+    def __init__(
+        self,
+        vocab_size: int,
+        n_layers: int,
+        embed_dim: int,
+        n_heads: int,
+        attn_length: int,
+        mlp_ratio: float = 4,
+        dropout: float = 0.1,
+        embd_dropout: float = None,
+    ):
         """
         Args:
             vocab_size: number of tokens in the vocabulary
@@ -50,31 +59,48 @@ class MinGPT(ConfigModule):
             configo = dict(vocab_size=vocab_size,n_layers=n_layers,embed_dim=embed_dim,n_heads=n_heads,
                         attn_length=attn_length,mlp_ratio=mlp_ratio,dropout=dropout,embd_dropout=embd_dropout)
         """
-        configo = dict(vocab_size=vocab_size,n_layers=n_layers,embed_dim=embed_dim,n_heads=n_heads,
-                            attn_length=attn_length,mlp_ratio=mlp_ratio,dropout=dropout,embd_dropout=embd_dropout)
+        configo = dict(
+            vocab_size=vocab_size,
+            n_layers=n_layers,
+            embed_dim=embed_dim,
+            n_heads=n_heads,
+            attn_length=attn_length,
+            mlp_ratio=mlp_ratio,
+            dropout=dropout,
+            embd_dropout=embd_dropout,
+        )
         super().__init__(configo)
 
         self.attn_length = attn_length
 
-
-        if(embd_dropout is None):
+        if embd_dropout is None:
             embd_dropout = dropout
 
-        block_config = dict(embed_dim=embed_dim, n_heads=n_heads,attn_length=attn_length, mlp_ratio=mlp_ratio,dropout=dropout)
-        self.transformer = nn.ModuleDict(dict(
-            token_embedder = nn.Embedding(vocab_size, embed_dim),
-            position_embedder = nn.Embedding(attn_length, embed_dim),
-            drop = nn.Dropout(embd_dropout),
-            h = nn.ModuleList([Block(**block_config) for _ in range(n_layers)]),
-            ln_f = nn.LayerNorm(embed_dim),
-        ))
+        block_config = dict(
+            embed_dim=embed_dim,
+            n_heads=n_heads,
+            attn_length=attn_length,
+            mlp_ratio=mlp_ratio,
+            dropout=dropout,
+        )
+        self.transformer = nn.ModuleDict(
+            dict(
+                token_embedder=nn.Embedding(vocab_size, embed_dim),
+                position_embedder=nn.Embedding(attn_length, embed_dim),
+                drop=nn.Dropout(embd_dropout),
+                h=nn.ModuleList([Block(**block_config) for _ in range(n_layers)]),
+                ln_f=nn.LayerNorm(embed_dim),
+            )
+        )
         self.lm_head = nn.Linear(embed_dim, vocab_size, bias=False)
 
-        print("number of parameters: %.2fM" % (self.paranum/1e6,))
-        print("Without head : %.2fM" % ((self.paranum-sum(p.numel() for p in self.lm_head.parameters()))/1e6))
+        print("number of parameters: %.2fM" % (self.paranum / 1e6,))
+        print(
+            "Without head : %.2fM"
+            % ((self.paranum - sum(p.numel() for p in self.lm_head.parameters())) / 1e6)
+        )
 
-
-    def forward(self, idx)-> torch.Tensor:
+    def forward(self, idx) -> torch.Tensor:
         """
         Process sequence of digits and outputs logits
 
@@ -86,27 +112,34 @@ class MinGPT(ConfigModule):
             (B,T,vocab_size) Tensor of logits.
         """
         B, T = idx.shape
-        assert T <= self.attn_length, f"Cannot forward sequence of length {T}, block size is only {self.attn_length}"
+        assert (
+            T <= self.attn_length
+        ), f"Cannot forward sequence of length {T}, block size is only {self.attn_length}"
 
-        pos = torch.arange(0, T, dtype=torch.long, device=self.device).unsqueeze(0) # shape (1, T)
+        # shape (1, T)
+        pos = torch.arange(0, T, dtype=torch.long, device=self.device).unsqueeze(0)
 
         # forward the GPT model
-        tok_emb = self.transformer.token_embedder(idx) # token embeddings of shape (B, T, n_embd)
+        # token embeddings of shape (B, T, n_embd)
+        tok_emb = self.transformer.token_embedder(idx)
 
-        pos_emb = self.transformer.position_embedder(pos) # position embeddings of shape (1, T, n_embd)
+        # position embeddings of shape (1, T, n_embd)
+        pos_emb = self.transformer.position_embedder(pos)
 
         idx = self.transformer.drop(tok_emb + pos_emb)
 
         for block in self.transformer.h:
             idx = block(idx)
-        idx = self.transformer.ln_f(idx) # Still (B,T,n_embd)
+        idx = self.transformer.ln_f(idx)  # Still (B,T,n_embd)
 
-        logits = self.lm_head(idx) # (B,T,vocab_size) logits
+        logits = self.lm_head(idx)  # (B,T,vocab_size) logits
 
-        return logits # (B,T,vocab_size)
+        return logits  # (B,T,vocab_size)
 
     @torch.no_grad()
-    def generate(self, idx, max_new_tokens, temperature=1.0, do_sample=False, top_k=None):
+    def generate(
+        self, idx, max_new_tokens, temperature=1.0, do_sample=False, top_k=None
+    ):
         """
         Take a conditioning sequence of indices idx (LongTensor of shape (B,T))
         and complete the sequence max_new_tokens times, feeding the predictions
@@ -130,14 +163,16 @@ class MinGPT(ConfigModule):
         """
 
         for _ in tqdm(range(max_new_tokens)):
-            idx_next = self.generate_next_token(idx,temperature=temperature,do_sample=do_sample,top_k=top_k)
+            idx_next = self.generate_next_token(
+                idx, temperature=temperature, do_sample=do_sample, top_k=top_k
+            )
 
             idx = torch.cat((idx, idx_next), dim=1)
 
         return idx
 
     @torch.no_grad()
-    def generate_next_token(self,idx,temperature=1.0, do_sample=False, top_k=None):
+    def generate_next_token(self, idx, temperature=1.0, do_sample=False, top_k=None):
         """
         Take a conditioning sequence of indices idx (LongTensor of shape (B,T))
         and complete the sequence max_new_tokens times, feeding the predictions
@@ -159,7 +194,9 @@ class MinGPT(ConfigModule):
         Returns:
             next predicted token, Long
         """
-        idx_cond = idx if idx.shape[1] <= self.attn_length else idx[:, -self.attn_length:]
+        idx_cond = (
+            idx if idx.shape[1] <= self.attn_length else idx[:, -self.attn_length :]
+        )
         # forward the model to get the logits for the index in the sequence
         logits = self.forward(idx_cond)
         # pluck the logits at the final step and scale by desired temperature
@@ -167,7 +204,7 @@ class MinGPT(ConfigModule):
         # optionally crop the logits to only the top k options
         if top_k is not None:
             v, _ = torch.topk(logits, top_k)
-            logits[logits < v[:, [-1]]] = -float('Inf')
+            logits[logits < v[:, [-1]]] = -float("Inf")
         # apply softmax to convert logits to (normalized) probabilities
         probs = F.softmax(logits, dim=-1)
 
@@ -178,7 +215,6 @@ class MinGPT(ConfigModule):
             _, idx_next = torch.topk(probs, k=1, dim=-1)
         # append sampled index to the running sequence and continue
         return idx_next
-
 
 
 class CausalSelfAttention(DevModule):
@@ -194,9 +230,13 @@ class CausalSelfAttention(DevModule):
         dropout: (optional) dropout probability
     """
 
-    def __init__(self, embed_dim : int, n_heads :int, attn_length:int, dropout:float = 0.1):
+    def __init__(
+        self, embed_dim: int, n_heads: int, attn_length: int, dropout: float = 0.1
+    ):
         super().__init__()
-        assert embed_dim % n_heads == 0, 'Number of heads {n_head} must divide embedding dim {n_embd}'
+        assert (
+            embed_dim % n_heads == 0
+        ), f"Number of heads {n_head} must divide embedding dim {n_embd}"
         # key, query, value projections for all heads, but in a batch
         self.c_attn = nn.Linear(embed_dim, 3 * embed_dim)
 
@@ -207,28 +247,37 @@ class CausalSelfAttention(DevModule):
         self.attn_dropout = nn.Dropout(dropout)
         self.resid_dropout = nn.Dropout(dropout)
         # causal mask to ensure that attention is only applied to the left in the input sequence
-        self.register_buffer("bias", torch.tril(torch.ones(attn_length, attn_length))
-                                     .view(1, 1, attn_length, attn_length))
+        self.register_buffer(
+            "bias",
+            torch.tril(torch.ones(attn_length, attn_length)).view(
+                1, 1, attn_length, attn_length
+            ),
+        )
         self.n_heads = n_heads
         self.embed_dim = embed_dim
 
     def forward(self, x):
-        B, T, C = x.size() # batch size, sequence length, embedding dimensionality (n_embd)
+        # batch size, sequence length, embedding dimensionality (n_embd)
+        B, T, C = x.size()
 
         # calculate query, key, values for all heads in batch and move head forward to be the batch dim
-        q, k ,v  = self.c_attn(x).split(self.embed_dim, dim=2)
-        k = k.reshape(B, T, self.n_heads, C // self.n_heads).transpose(1, 2) # (B, nh, T, hs)
-        q = q.reshape(B, T, self.n_heads, C // self.n_heads).transpose(1, 2) # (B, nh, T, hs)
-        v = v.reshape(B, T, self.n_heads, C // self.n_heads).transpose(1, 2) # (B, nh, T, hs)
+        q, k, v = self.c_attn(x).split(self.embed_dim, dim=2)
+        # (B, nh, T, hs)
+        k = k.reshape(B, T, self.n_heads, C // self.n_heads).transpose(1, 2)
+        # (B, nh, T, hs)
+        q = q.reshape(B, T, self.n_heads, C // self.n_heads).transpose(1, 2)
+        # (B, nh, T, hs)
+        v = v.reshape(B, T, self.n_heads, C // self.n_heads).transpose(1, 2)
 
         # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
         x = (q @ k.transpose(-2, -1)) * (1.0 / math.sqrt(k.size(-1)))
-        x = x.masked_fill(self.bias[:,:,:T,:T] == 0, float('-inf'))
+        x = x.masked_fill(self.bias[:, :, :T, :T] == 0, float("-inf"))
         x = F.softmax(x, dim=-1)
         x = self.attn_dropout(x)
 
-        x = x @ v # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
-        x = x.transpose(1, 2).contiguous().reshape(B, T, C) # re-assemble all head outputs side by side
+        x = x @ v  # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
+        # re-assemble all head outputs side by side
+        x = x.transpose(1, 2).contiguous().reshape(B, T, C)
 
         # output projection
         x = self.resid_dropout(self.c_proj(x))
@@ -248,25 +297,38 @@ class Block(DevModule):
         dropout: (optional) dropout probability
     """
 
-    def __init__(self, embed_dim :int, n_heads:int,attn_length:int, mlp_ratio:float,dropout:float=0.1):
+    def __init__(
+        self,
+        embed_dim: int,
+        n_heads: int,
+        attn_length: int,
+        mlp_ratio: float,
+        dropout: float = 0.1,
+    ):
         super().__init__()
 
         self.ln_1 = nn.LayerNorm(embed_dim)
-        self.attn = CausalSelfAttention(embed_dim=embed_dim,n_heads=n_heads,attn_length=attn_length,dropout=dropout)
+        self.attn = CausalSelfAttention(
+            embed_dim=embed_dim,
+            n_heads=n_heads,
+            attn_length=attn_length,
+            dropout=dropout,
+        )
         self.ln_2 = nn.LayerNorm(embed_dim)
 
-        self.mlp = nn.ModuleDict(dict(
-            c_fc    = nn.Linear(embed_dim, int(mlp_ratio * embed_dim)),
-            act     = nn.GELU(),
-            c_proj  = nn.Linear(int(mlp_ratio * embed_dim), embed_dim),
-            dropout = nn.Dropout(dropout),
-        ))
-
+        self.mlp = nn.ModuleDict(
+            dict(
+                c_fc=nn.Linear(embed_dim, int(mlp_ratio * embed_dim)),
+                act=nn.GELU(),
+                c_proj=nn.Linear(int(mlp_ratio * embed_dim), embed_dim),
+                dropout=nn.Dropout(dropout),
+            )
+        )
 
     def forward(self, x):
         x = x + self.attn(self.ln_1(x))
-        x = x + self.mlp['dropout'](self.mlp['c_proj'](self.mlp['act'](self.mlp['c_fc'](self.ln_2(x)))))
+        x = x + self.mlp["dropout"](
+            self.mlp["c_proj"](self.mlp["act"](self.mlp["c_fc"](self.ln_2(x))))
+        )
 
         return x
-
-

--- a/modules/models/mingpt/MinGPT.py
+++ b/modules/models/mingpt/MinGPT.py
@@ -236,7 +236,7 @@ class CausalSelfAttention(DevModule):
         super().__init__()
         assert (
             embed_dim % n_heads == 0
-        ), f"Number of heads {n_head} must divide embedding dim {n_embd}"
+        ), f"Number of heads {n_heads} must divide embedding dim {embed_dim}"
         # key, query, value projections for all heads, but in a batch
         self.c_attn = nn.Linear(embed_dim, 3 * embed_dim)
 

--- a/modules/models/mingpt/MinGPT_Trainer.py
+++ b/modules/models/mingpt/MinGPT_Trainer.py
@@ -16,31 +16,67 @@ from ...tokenizer import Tokenizer
 
 
 class MinGPT_Trainer(Trainer):
-    def __init__(self, model: MinGPT, train_dataset: TokenText, valid_dataset : TokenText, backwards : bool=True,
-                 detokenizer :Tokenizer=None, optim: Optimizer = None, scheduler: _LRScheduler = None,
-                 state_save_loc=None, device: str = 'cpu',parallel=None, run_name: str = None, project_name: str = None,
-                 run_config: dict ={}):
-        super().__init__(model, optim, scheduler, save_loc=state_save_loc, device=device, parallel=parallel,
-                         run_name=run_name, project_name=project_name, run_config=run_config)
+    def __init__(
+        self,
+        model: MinGPT,
+        train_dataset: TokenText,
+        valid_dataset: TokenText,
+        backwards: bool = True,
+        detokenizer: Tokenizer = None,
+        optim: Optimizer = None,
+        scheduler: _LRScheduler = None,
+        state_save_loc=None,
+        device: str = "cpu",
+        parallel=None,
+        run_name: str = None,
+        project_name: str = None,
+        run_config: dict = {},
+    ):
+        super().__init__(
+            model,
+            optim,
+            scheduler,
+            save_loc=state_save_loc,
+            device=device,
+            parallel=parallel,
+            run_name=run_name,
+            project_name=project_name,
+            run_config=run_config,
+        )
 
         self.train_dataset = train_dataset
         self.valid_dataset = valid_dataset
         # For logging :
         self.batch_loss = []
 
-        self.detokenizer= detokenizer
+        self.detokenizer = detokenizer
 
-        self.backwards = backwards # In principle, extractable form dataset, but annoying because I use Subset, so I just give it.
+        # In principle, extractable form dataset, but annoying because I use
+        # Subset, so I just give it.
+        self.backwards = backwards
 
         # Print number of parameters
-        print(f"Number of parameters : {sum(p.numel() for p in self.model.parameters())/1e6:.2f}M")
+        print(
+            f"Number of parameters : {sum(p.numel() for p in self.model.parameters())/1e6:.2f}M"
+        )
 
-    def get_loaders(self,batch_size,num_workers=0):
-        # note shuffle= False because both are pre-shuffled; that way we can restart deterministically from same point
-        t_dataloader = DataLoader(self.train_dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers)
-        v_dataloader = DataLoader(self.valid_dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers)
+    def get_loaders(self, batch_size, num_workers=0):
+        # note shuffle= False because both are pre-shuffled; that way we can
+        # restart deterministically from same point
+        t_dataloader = DataLoader(
+            self.train_dataset,
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=num_workers,
+        )
+        v_dataloader = DataLoader(
+            self.valid_dataset,
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=num_workers,
+        )
 
-        self.text_table = wandb.Table(columns=["batches","text"])
+        self.text_table = wandb.Table(columns=["batches", "text"])
 
         return t_dataloader, v_dataloader
 
@@ -48,24 +84,24 @@ class MinGPT_Trainer(Trainer):
         # Compute the loss, and log the learning rate
         loss = self.compute_loss(batch_data)
 
-        if(self.do_step_log) :
-            self.logger.log({'lr' : self.scheduler.get_last_lr()[0]},commit=False)
+        if self.do_step_log:
+            self.logger.log({"lr": self.scheduler.get_last_lr()[0]}, commit=False)
 
         return loss
 
     def compute_loss(self, batch_data):
         token_in, token_truth = batch_data
-        B,T = token_truth.shape
+        B, T = token_truth.shape
 
         token_in = token_in.to(self.device)
-        token_truth = token_truth.to(self.device) # (B, T)
+        token_truth = token_truth.to(self.device)  # (B, T)
 
         token_in = self.model.forward(token_in)
         # RESHAPE OTHERWISE, CROSS ENTROPY LOSS BUGS FOR BIG BATCHES
-        token_in = token_in.reshape(B*T,-1) # (B*T, C)
-        token_truth = token_truth.reshape(B*T)
+        token_in = token_in.reshape(B * T, -1)  # (B*T, C)
+        token_truth = token_truth.reshape(B * T)
 
-        loss = F.cross_entropy(token_in,token_truth,reduction='mean')
+        loss = F.cross_entropy(token_in, token_truth, reduction="mean")
 
         return loss
 
@@ -78,25 +114,32 @@ class MinGPT_Trainer(Trainer):
         """
         Log a snippet of generated text in a wandb Table
         """
-        data, _ = self.valid_dataset[random.randint(0,len(self.valid_dataset)-1)] # (T,)*2
-        data = data[:5].to(self.device) # only keep first 5 tokens, to start generating
-        if(self.parallel_train):
+        # (T,)*2
+        data, _ = self.valid_dataset[
+            random.randint(0, len(self.valid_dataset) - 1)
+        ]
+        data = data[:5].to(self.device)  # only keep first 5 tokens, to start generating
+        if self.parallel_train:
             modello = self.model.module
         else:
             modello = self.model
         # Generate some tokens
-        phrase_out = modello.generate(data[None,:],max_new_tokens=100, do_sample=True).cpu() # (1, 5+300)
+        phrase_out = modello.generate(
+            data[None, :], max_new_tokens=100, do_sample=True
+        ).cpu()  # (1, 5+300)
 
         # Decode the tokens, and if backwards, flip them back
-        if(self.backwards):
-            phrase_out= self.detokenizer.detokenize(torch.flip(phrase_out,dims=[1])) # ()
-        else :
-            phrase_out=self.detokenizer.detokenize(phrase_out)
+        if self.backwards:
+            phrase_out = self.detokenizer.detokenize(
+                torch.flip(phrase_out, dims=[1])
+            )  # ()
+        else:
+            phrase_out = self.detokenizer.detokenize(phrase_out)
 
-        self.text_table.add_data(f"{self.steps_done/1000:.1f}k",phrase_out)
+        self.text_table.add_data(f"{self.steps_done/1000:.1f}k", phrase_out)
         # Fucking wandb... To update the table before end, need to re-create one each time
         new_table = wandb.Table(
-        columns=self.text_table.columns, data=self.text_table.data
+            columns=self.text_table.columns, data=self.text_table.data
         )
 
-        wandb.log({'gen_samples': new_table},commit=False)
+        wandb.log({"gen_samples": new_table}, commit=False)

--- a/modules/tok_utils/create_custom_tokenizer.py
+++ b/modules/tok_utils/create_custom_tokenizer.py
@@ -6,6 +6,7 @@ File should contain regular spaces, otherwise it might crash with OOM error.
 """
 
 import os
+import argparse
 
 from transformers import AutoTokenizer
 
@@ -81,7 +82,7 @@ def create_tokenizer(txt_path, save_directory = None, tokenizer_name=None, vocab
         save_directory: Directory where the tokenizer will be saved. If None,
             will be saved in the same directory as the .txt file.
         tokenizer_name: Name of the tokenizer. If None, will be the name of the
-            .txt file, followed by _tokenizer.
+            .txt file, followed by `_tokenizer`.
         vocab_size: Size of the vocabulary to use for the tokenizer. Default is
             50257, which is the GPT2 vocabulary size.
     """
@@ -90,6 +91,7 @@ def create_tokenizer(txt_path, save_directory = None, tokenizer_name=None, vocab
 
     if tokenizer_name is None:
         tokenizer_name = f'{os.path.basename(txt_path).split(".")[0]}_tokenizer'
+        print(f"No tokenizer name provided, defaulting to: {tokenizer_name}")
 
     toke_base = AutoTokenizer.from_pretrained('gpt2',use_fast=True) # Load gpt2 tokenizer, to get same vocab_size and special tokens
     # .txt dataset (full dataset in the txt file, for now.)
@@ -97,7 +99,55 @@ def create_tokenizer(txt_path, save_directory = None, tokenizer_name=None, vocab
     toke_mine.save_pretrained(os.path.join(save_directory, tokenizer_name)) # Save the tokenizer
 
 
-if __name__=="__main__":
-    txt_path = 'datavol/vi.txt'
+if __name__ == "__main__":
 
-    create_tokenizer(txt_path, 'vi',vocab_size=50257)
+    parser = argparse.ArgumentParser(
+        description="""
+        Trains a Huggingface Tokenizer with BPE. Only work on a single .txt
+        file. Should be no bigger than ~50 GB, to avoid memory issues.
+        """
+    )
+
+    parser.add_argument(
+        "input_file",
+        type=str,
+        help="""
+        Path to the .txt file to use for training the tokenizer.
+        """
+    )
+
+    parser.add_argument(
+        "--output_directory", "-d",
+        type=str,
+        help="""
+        Directory where the tokenizer will be saved. If None,
+        will be saved in the same directory as the .txt file.
+        """
+    )
+
+    parser.add_argument(
+        "--tokenizer_name", "-t",
+        type=str,
+        default=None,
+        help="""
+        Name of the tokenizer. If None, will be the name of the
+        .txt file, followed by `_tokenizer`. Default is None.
+        """
+    )
+
+    parser.add_argument(
+        "--vocab_size",
+        type=int,
+        default=50257,
+        help="""
+        Size of the vocabulary to use for the tokenizer.
+        Default is 50257, which is the GPT2 vocabulary size.
+        """
+    )
+
+    args = parser.parse_args()
+
+    create_tokenizer(
+        txt_path = args.input_file, save_directory = args.output_directory,
+        tokenizer_name = args.tokenizer_name, vocab_size = args.vocab_size,
+    )

--- a/modules/tok_utils/create_custom_tokenizer.py
+++ b/modules/tok_utils/create_custom_tokenizer.py
@@ -11,65 +11,71 @@ import argparse
 from transformers import AutoTokenizer
 
 
-def read_in_chunks(file_path, chunk_size=10*1024*1024):  # Default chunk size is 10MB
+# Default chunk size is 10MB
+def read_in_chunks(file_path, chunk_size=10 * 1024 * 1024):
     """
     Generator to yield chunks of text from a large file.
     TODO : Add support for .txt files which are not unified
     """
     counter = 0
-    with open(file_path, 'r', encoding='utf-8', errors='ignore') as file:
+    with open(file_path, "r", encoding="utf-8", errors="ignore") as file:
         while True:
             chunk = file.read(chunk_size)
             if not chunk:  # End of file
                 break
-            counter+=1
-            if(counter%50==0):
-                print(f'Processed {counter*chunk_size/(1024*1024*1024):.1f}GB')
+            counter += 1
+            if counter % 50 == 0:
+                print(f"Processed {counter*chunk_size/(1024*1024*1024):.1f}GB")
             yield chunk
 
-def read_in_lines(file_path, batch_size=512, phrase_size=2048):  # phrase_size is approx number of characters in a element
+
+def read_in_lines(
+    file_path, batch_size=512, phrase_size=2048
+):  # phrase_size is approx number of characters in a element
     """
     Generator to yield chunks of text from a large file.
     TODO : Add support for .txt files which are not unified
     """
     counter = 0
-    total_line_weight=0
+    total_line_weight = 0
 
-    with open(file_path, 'r', encoding='utf-8', errors='ignore') as file:
-        done=False
+    with open(file_path, "r", encoding="utf-8", errors="ignore") as file:
+        done = False
         while not done:
-            lines=[]
-            newline=''
+            lines = []
+            newline = ""
 
-            while (len(lines)<batch_size and not done):
-                while(len(newline)<=phrase_size):
-                    #Read lines until we get something long enough
-                    extra=file.readline()
+            while len(lines) < batch_size and not done:
+                while len(newline) <= phrase_size:
+                    # Read lines until we get something long enough
+                    extra = file.readline()
                     if not extra:  # End of file
-                        done=True
-                        print('YAY DONE')
+                        done = True
+                        print("YAY DONE")
                         break
-                    newline = newline+extra
+                    newline = newline + extra
 
-                if(len(newline)>1.5*phrase_size):
+                if len(newline) > 1.5 * phrase_size:
                     # In case of big overshoot, split the line
-                    while(len(newline)>phrase_size):
+                    while len(newline) > phrase_size:
                         lines.append(newline[:phrase_size])
-                        newline=newline[phrase_size:]
+                        newline = newline[phrase_size:]
 
                 # Append the newline, or what's left of it
                 lines.append(newline)
-                newline=''
+                newline = ""
 
-            total_line_weight+=len('\n'.join(lines).encode('utf-8')) # in bytes
-            counter+=1
-            if(counter%300==0):
-                print(f'Processed ~{total_line_weight/(1024*1024*1024):.1f}GB\n')
+            total_line_weight += len("\n".join(lines).encode("utf-8"))  # in bytes
+            counter += 1
+            if counter % 300 == 0:
+                print(f"Processed ~{total_line_weight/(1024*1024*1024):.1f}GB\n")
 
             yield lines
 
 
-def create_tokenizer(txt_path, save_directory = None, tokenizer_name=None, vocab_size=50257):
+def create_tokenizer(
+    txt_path, save_directory=None, tokenizer_name=None, vocab_size=50257
+):
     """
     Creates a custom BPE huggingface tokenizer from a .txt file. The tokenizer
     is saved as a folder, and can be loaded with the helper function
@@ -93,14 +99,18 @@ def create_tokenizer(txt_path, save_directory = None, tokenizer_name=None, vocab
         tokenizer_name = f'{os.path.basename(txt_path).split(".")[0]}_tokenizer'
         print(f"No tokenizer name provided, defaulting to: {tokenizer_name}")
 
-    toke_base = AutoTokenizer.from_pretrained('gpt2',use_fast=True) # Load gpt2 tokenizer, to get same vocab_size and special tokens
+    # Load gpt2 tokenizer, to get same vocab_size and special tokens
+    toke_base = AutoTokenizer.from_pretrained("gpt2", use_fast=True)
     # .txt dataset (full dataset in the txt file, for now.)
-    toke_mine= toke_base.train_new_from_iterator(read_in_lines(txt_path),vocab_size=vocab_size) # Train new tokenizer using BPE
-    toke_mine.save_pretrained(os.path.join(save_directory, tokenizer_name)) # Save the tokenizer
+    toke_mine = toke_base.train_new_from_iterator(
+        read_in_lines(txt_path), vocab_size=vocab_size
+    )  # Train new tokenizer using BPE
+    toke_mine.save_pretrained(
+        os.path.join(save_directory, tokenizer_name)
+    )  # Save the tokenizer
 
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser(
         description="""
         Trains a Huggingface Tokenizer with BPE. Only work on a single .txt
@@ -113,7 +123,7 @@ if __name__ == "__main__":
         type=str,
         help="""
         Path to the .txt file to use for training the tokenizer.
-        """
+        """,
     )
 
     parser.add_argument(
@@ -122,7 +132,7 @@ if __name__ == "__main__":
         help="""
         Directory where the tokenizer will be saved. If None,
         will be saved in the same directory as the .txt file.
-        """
+        """,
     )
 
     parser.add_argument(
@@ -132,7 +142,7 @@ if __name__ == "__main__":
         help="""
         Name of the tokenizer. If None, will be the name of the
         .txt file, followed by `_tokenizer`. Default is None.
-        """
+        """,
     )
 
     parser.add_argument(
@@ -142,12 +152,14 @@ if __name__ == "__main__":
         help="""
         Size of the vocabulary to use for the tokenizer.
         Default is 50257, which is the GPT2 vocabulary size.
-        """
+        """,
     )
 
     args = parser.parse_args()
 
     create_tokenizer(
-        txt_path = args.input_file, save_directory = args.output_directory,
-        tokenizer_name = args.tokenizer_name, vocab_size = args.vocab_size,
+        txt_path=args.input_file,
+        save_directory=args.output_directory,
+        tokenizer_name=args.tokenizer_name,
+        vocab_size=args.vocab_size,
     )

--- a/modules/tok_utils/pt_to_h5.py
+++ b/modules/tok_utils/pt_to_h5.py
@@ -1,9 +1,12 @@
 import os
 import h5py
+import argparse
 from tqdm import tqdm
 from pathlib import Path
 
 import torch
+
+from modules import tokenizer
 
 from transformers import AutoTokenizer
 
@@ -23,7 +26,7 @@ def make_h5(pt_data_folder, dataset_fname = 'dataset.h5', destination_folder = N
     """
 
     if(view_tokenizer is None):
-        view_tokenizer = AutoTokenizer.from_pretrained('gpt2',use_fast=True)
+        view_tokenizer = tokenizer.get_tokenizer(m_name='gpt2')
 
     if(destination_folder is None):
         destination_folder= Path(__file__).parent.as_posix()
@@ -57,5 +60,59 @@ def make_h5(pt_data_folder, dataset_fname = 'dataset.h5', destination_folder = N
         raise ValueError(f'{pt_data_folder} not found')
 
 
-if __name__=='__main__':
-    make_h5('testdata', destination_folder='test_h5')
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        description="""
+        Converts saved PyTorch tensors (.pt) into an .h5 dataset.
+        """
+    )
+
+    parser.add_argument(
+        "input_directory",
+        type=str,
+        help="""
+        Path to the folder containing the .pt files. Can be
+        relative or absolute.
+        """
+    )
+
+    parser.add_argument(
+        "--output_directory", "-d",
+        type=str,
+        help="""
+        Path to the folder where the .h5 file will be saved.
+        Can be relative or absolute.
+        """
+    )
+
+    parser.add_argument(
+        "--dataset_name", "-n",
+        type=str,
+        help="""
+        Name of the dataset file to be produced. Defaults to
+        `dataset.h5` ('.h5' will automatically be added at the
+        end if missing).
+        """
+    )
+
+    # TODO: implement the choice of tokenizer (HF or local)
+    # parser.add_argument(
+    #     "--tokenizer", "-t",
+    #     type=str,
+    #     help="""
+    #     A tokenizer to use for viewing dataset snippets during
+    #     conversion. If None, will use the GPT2 tokenizer.
+    #     """
+    # )
+
+    args = parser.parse_args()
+
+    make_h5(
+        pt_data_folder = args.input_directory,
+        dataset_fname = args.dataset_name,
+        destination_folder = args.output_directory,
+        # TODO: implement the choice of tokenizer (HF or local), like in
+        # ../tokenizer.py
+        view_tokenizer = None,
+    )

--- a/modules/tok_utils/pt_to_h5.py
+++ b/modules/tok_utils/pt_to_h5.py
@@ -10,7 +10,13 @@ from modules import tokenizer
 
 from transformers import AutoTokenizer
 
-def make_h5(pt_data_folder, dataset_fname = 'dataset.h5', destination_folder = None, view_tokenizer : AutoTokenizer = None):
+
+def make_h5(
+    pt_data_folder,
+    dataset_fname="dataset.h5",
+    destination_folder=None,
+    view_tokenizer: AutoTokenizer = None,
+):
     """
     Takes a folder of .pt files, and converts them to a single .h5 file.
 
@@ -25,43 +31,46 @@ def make_h5(pt_data_folder, dataset_fname = 'dataset.h5', destination_folder = N
             during conversion. If None, will use the GPT2 tokenizer.
     """
 
-    if(view_tokenizer is None):
-        view_tokenizer = tokenizer.get_tokenizer(m_name='gpt2')
+    if view_tokenizer is None:
+        view_tokenizer = tokenizer.get_tokenizer(m_name="gpt2")
 
-    if(destination_folder is None):
-        destination_folder= Path(__file__).parent.as_posix()
+    if destination_folder is None:
+        destination_folder = Path(__file__).parent.as_posix()
 
-    if not dataset_fname.endswith('.h5') : dataset_fname = f"{dataset_fname}.h5"
+    if not dataset_fname.endswith(".h5"):
+        dataset_fname = f"{dataset_fname}.h5"
 
     tarname = os.path.join(destination_folder, dataset_fname)
-    os.makedirs(os.path.dirname(tarname),exist_ok=True)
+    os.makedirs(os.path.dirname(tarname), exist_ok=True)
 
-    if(os.path.isdir(pt_data_folder)):
-        with h5py.File(tarname, 'w') as f:
-            dset = f.create_dataset("tokens", (0,), maxshape=(None,), dtype='int32')  # note the maxshape parameter
+    if os.path.isdir(pt_data_folder):
+        with h5py.File(tarname, "w") as f:
+            # note the maxshape parameter
+            dset = f.create_dataset("tokens", (0,), maxshape=(None,), dtype="int32")
 
             current_index = 0
             for file in tqdm(os.listdir(pt_data_folder)):
-                if os.path.splitext(file)[1]=='.pt':
-                    pt_file = os.path.join(pt_data_folder,file)
-                    tensor = torch.load(pt_file,map_location=torch.device('cpu'))
+                if os.path.splitext(file)[1] == ".pt":
+                    pt_file = os.path.join(pt_data_folder, file)
+                    tensor = torch.load(pt_file, map_location=torch.device("cpu"))
                     length = tensor.shape[1]
 
-                    print('snippet : \n', view_tokenizer.detokenize(tensor[:,:40]))
+                    print("snippet : \n", view_tokenizer.detokenize(tensor[:, :40]))
                     # Resize the dataset to accommodate the new data
                     dset.resize((current_index + length,))
 
                     # Add the new data to the dataset
-                    dset[current_index:current_index+length] = tensor.numpy().squeeze()
+                    dset[current_index : current_index + length] = (
+                        tensor.numpy().squeeze()
+                    )
 
                     # Update the current ind
                     current_index += length
-    else :
-        raise ValueError(f'{pt_data_folder} not found')
+    else:
+        raise ValueError(f"{pt_data_folder} not found")
 
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser(
         description="""
         Converts saved PyTorch tensors (.pt) into an .h5 dataset.
@@ -74,7 +83,7 @@ if __name__ == "__main__":
         help="""
         Path to the folder containing the .pt files. Can be
         relative or absolute.
-        """
+        """,
     )
 
     parser.add_argument(
@@ -83,7 +92,7 @@ if __name__ == "__main__":
         help="""
         Path to the folder where the .h5 file will be saved.
         Can be relative or absolute.
-        """
+        """,
     )
 
     parser.add_argument(
@@ -93,7 +102,7 @@ if __name__ == "__main__":
         Name of the dataset file to be produced. Defaults to
         `dataset.h5` ('.h5' will automatically be added at the
         end if missing).
-        """
+        """,
     )
 
     # TODO: implement the choice of tokenizer (HF or local)
@@ -109,10 +118,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     make_h5(
-        pt_data_folder = args.input_directory,
-        dataset_fname = args.dataset_name,
-        destination_folder = args.output_directory,
+        pt_data_folder=args.input_directory,
+        dataset_fname=args.dataset_name,
+        destination_folder=args.output_directory,
         # TODO: implement the choice of tokenizer (HF or local), like in
         # ../tokenizer.py
-        view_tokenizer = None,
+        view_tokenizer=None,
     )

--- a/modules/tok_utils/tokenize_to_pt.py
+++ b/modules/tok_utils/tokenize_to_pt.py
@@ -22,7 +22,6 @@ command line arguments.
 
 import os
 import shutil
-import pathlib
 import argparse
 from tqdm import tqdm
 
@@ -63,7 +62,6 @@ def split_file(filename, split_dir):
     part_size = MAX_SIZE  # 500MB
     part_num = 1
 
-    counter = 0
     with open(filename, "rb") as source:
         while True:
             # Read up to the desired part size
@@ -105,7 +103,6 @@ def main_split_large(folder_path, target_path):
         target_path: Path to the folder that will contain the splits (created
             if needed).
     """
-    folder_name = os.path.basename(os.path.normpath(folder_path))
     os.makedirs(target_path, exist_ok=True)
 
     for filename in os.listdir(folder_path):

--- a/modules/tokenizer.py
+++ b/modules/tokenizer.py
@@ -12,60 +12,130 @@ import torch
 from transformers import logging
 from transformers import AutoTokenizer
 
-logging.set_verbosity_error() # needed to stop the stupid warning messages
+logging.set_verbosity_error()  # needed to stop the stupid warning messages
 
 ##################
 ### MINI-UTILS ###
 ##################
 
-def log(*args): print(*args)
 
-def all_none(* args): return all([arg is None for arg in args])
-def all_not_none(* args): return all([arg is not None for arg in args])
-def is_any_none(*args): return not all_not_none(*args)
-def any_not_none(* args): return any([arg is not None for arg in args])
-def first_not_none(* args): return None if len(args) == 0 else args[0] if args[0] is not None else first_not_none(* args[1:])
-def multiget(d, vals): return [d.get(val) for val in vals]
-def remove_none_vals(d): return { k:d[k] for k in d if d[k] is not None }
+def log(*args):
+    print(*args)
 
-def put_and_return(d, k, v): return d.update({k : v}) or v
 
-def is_file(file_path): return os.path.isfile(file_path)
-def are_files(*file_paths): return all([is_file(file_path) for file_path in file_paths])
-def list_dir_files(dir_path): # returns the files in a directory
-    return [file_name for file_name in os.listdir(dir_path) if is_file(os.path.join(dir_path, file_name))]
+def all_none(*args):
+    return all([arg is None for arg in args])
+
+
+def all_not_none(*args):
+    return all([arg is not None for arg in args])
+
+
+def is_any_none(*args):
+    return not all_not_none(*args)
+
+
+def any_not_none(*args):
+    return any([arg is not None for arg in args])
+
+
+def first_not_none(*args):
+    return (
+        None
+        if len(args) == 0
+        else args[0]
+        if args[0] is not None
+        else first_not_none(*args[1:])
+    )
+
+
+def multiget(d, vals):
+    return [d.get(val) for val in vals]
+
+
+def remove_none_vals(d):
+    return {k: d[k] for k in d if d[k] is not None}
+
+
+def put_and_return(d, k, v):
+    return d.update({k: v}) or v
+
+
+def is_file(file_path):
+    return os.path.isfile(file_path)
+
+
+def are_files(*file_paths):
+    return all([is_file(file_path) for file_path in file_paths])
+
+
+def list_dir_files(dir_path):  # returns the files in a directory
+    return [
+        file_name
+        for file_name in os.listdir(dir_path)
+        if is_file(os.path.join(dir_path, file_name))
+    ]
+
 
 def load_string(file_path):
-    try: return pathlib.Path(file_path).read_text(encoding='utf-8')
+    try:
+        return pathlib.Path(file_path).read_text(encoding="utf-8")
     except Exception as e:
         print(f"Load_string encountered an error when trying to load {file_path}")
         print(f"Exception {e=}")
-        return ''
+        return ""
+
 
 def save_string(string, file_path):
-    try: pathlib.Path(file_path).write_text(string,encoding='utf-8')
-    except Exception as e: return log(f"Error writing to {file_path=}, {e}")
+    try:
+        pathlib.Path(file_path).write_text(string, encoding="utf-8")
+    except Exception as e:
+        return log(f"Error writing to {file_path=}, {e}")
 
-def load_json(file_path): return json.loads(load_string(file_path))
-def save_json(obj, file_path): save_string(json.dumps(obj), file_path) or obj
+
+def load_json(file_path):
+    return json.loads(load_string(file_path))
+
+
+def save_json(obj, file_path):
+    save_string(json.dumps(obj), file_path) or obj
+
+
 def load_torch(file_path, *, device=None, **params):
-    return torch.load(file_path, map_location=(device if device is not None else 'cpu'), **params) # wrapper to unify notation
+    return torch.load(
+        file_path, map_location=(device if device is not None else "cpu"), **params
+    )  # wrapper to unify notation
+
+
 def save_torch(obj, file_path, *, replace=True, **params):
-    if not is_file(file_path) or replace: return torch.save(obj, file_path, **params) or obj # wrapper to unify notation
-    else: return obj
+    if not is_file(file_path) or replace:
+        return torch.save(obj, file_path, **params) or obj  # wrapper to unify notation
+    else:
+        return obj
 
-def sanitize_quotes(text): return text.replace('’',"'").replace('”', '"').replace('“', '"')
 
-def get_first_directory(path): return next((entry.name for entry in os.scandir(path) if entry.is_dir()), None)
+def sanitize_quotes(text):
+    return text.replace("’", "'").replace("”", '"').replace("“", '"')
+
+
+def get_first_directory(path):
+    return next((entry.name for entry in os.scandir(path) if entry.is_dir()), None)
+
 
 ####################
 ### TOKENIZATION ###
 ####################
 
+
 class Tokenizer:
-    """ The base class for the tokenizers """
-    def __init__(self): self.vs = 1
-    def tokenize(self, s, **params): pass # tokenizes a string into a batched tensor [1, t], t = num tokens of s
+    """The base class for the tokenizers"""
+
+    def __init__(self):
+        self.vs = 1
+
+    def tokenize(self, s, **params):
+        pass  # tokenizes a string into a batched tensor [1, t], t = num tokens of s
+
     def detokenize(self, tokens, *, join=True):
         """
         Converts a pytorch tensor of tokens into a string or a list of strings
@@ -74,20 +144,24 @@ class Tokenizer:
             tokens: size [t] or size [b, t] (in the latter case, will be converted to [b * t])
             join: whether to put the tokens together in a string or leave them as a list of words
         """
-        pass # detokenizes a pytorch tensor into a string
+        pass  # detokenizes a pytorch tensor into a string
+
     def tokenize_txt_to_pt(self, txt, *, add_if_unknown=False, dtype=None):
         tokens = self.tokenize(txt, add_if_unknown=add_if_unknown)
-        if dtype is not None and isinstance(dtype, torch.dtype): tokens = tokens.to(dtype)
-        log(f"Converted string length {len(txt)} into tensor of shape {tokens.shape} and of type {tokens.dtype}")
+        if dtype is not None and isinstance(dtype, torch.dtype):
+            tokens = tokens.to(dtype)
+        log(
+            f"Converted string length {len(txt)} into tensor of shape {tokens.shape} and of type {tokens.dtype}"
+        )
         return tokens
 
     def tokenize_txt_to_pt_chunks(self, txt, *, add_if_unknown, dtype=None):
         # Splitting the text into chunks
-        chunk_size = 1*1024*1024 # 10M tokens chunk size
-        chunks = [txt[i:i+chunk_size] for i in range(0, len(txt), chunk_size)]
+        chunk_size = 1 * 1024 * 1024  # 10M tokens chunk size
+        chunks = [txt[i : i + chunk_size] for i in range(0, len(txt), chunk_size)]
 
         tokenized_chunks = []
-        print('Tokenizing... ')
+        print("Tokenizing... ")
         for chunk in tqdm(chunks):
             tokens = self.tokenize(chunk, add_if_unknown=add_if_unknown)
             if dtype is not None and isinstance(dtype, torch.dtype):
@@ -95,76 +169,122 @@ class Tokenizer:
 
             tokenized_chunks.append(tokens)
 
-        print(f'Chunk size : {tokenized_chunks[0].shape}*{(1,len(chunks))}')
+        print(f"Chunk size : {tokenized_chunks[0].shape}*{(1,len(chunks))}")
         # If you want to return all chunks together:
-        return torch.cat(tokenized_chunks,dim=1)
+        return torch.cat(tokenized_chunks, dim=1)
 
-    def tokenize_txt_to_pt_file(self, txt, pt_file_path, *, add_if_unknown=False, dtype=None):
-        """ Converts a string to a torch.Long tensor made of the tokens, which we save into the pf_file_name """
-        save_torch(self.tokenize_txt_to_pt_chunks(txt, add_if_unknown=add_if_unknown, dtype=dtype), pt_file_path)
+    def tokenize_txt_to_pt_file(
+        self, txt, pt_file_path, *, add_if_unknown=False, dtype=None
+    ):
+        """Converts a string to a torch.Long tensor made of the tokens, which we save into the pf_file_name"""
+        save_torch(
+            self.tokenize_txt_to_pt_chunks(
+                txt, add_if_unknown=add_if_unknown, dtype=dtype
+            ),
+            pt_file_path,
+        )
 
-    def tokenize_txt_file_to_pt_file(self, txt_file_path, pt_file_path, *, add_if_unknown=False, dtype=None):
-        """ Converts a text file to a torch.Long tensor made of the tokens, which we save into the pf_file_name """
-        self.tokenize_txt_to_pt_file(load_string(txt_file_path), pt_file_path, add_if_unknown=add_if_unknown, dtype=dtype)
+    def tokenize_txt_file_to_pt_file(
+        self, txt_file_path, pt_file_path, *, add_if_unknown=False, dtype=None
+    ):
+        """Converts a text file to a torch.Long tensor made of the tokens, which we save into the pf_file_name"""
+        self.tokenize_txt_to_pt_file(
+            load_string(txt_file_path),
+            pt_file_path,
+            add_if_unknown=add_if_unknown,
+            dtype=dtype,
+        )
+
 
 class MinTokenizer(Tokenizer):
-    """ A basic tokenizer class that assumes that all tokens are one-character long, and that learns them on the fly """
+    """A basic tokenizer class that assumes that all tokens are one-character long, and that learns them on the fly"""
+
     def __init__(self, **params):
         super().__init__()
         # A bit hacky, but we should have a vs size consistent with the number of tokens
-        (self.t2i, self.i2t, self.vs) = ({ '[?]' : 0 }, { 0 : '[?]' }, 1) # token to int and int to token, vocab size
-        if (file_name := params.get('file_name')) is not None: self.load_from_json(file_name)
+        (self.t2i, self.i2t, self.vs) = (
+            {"[?]": 0},
+            {0: "[?]"},
+            1,
+        )  # token to int and int to token, vocab size
+        if (file_name := params.get("file_name")) is not None:
+            self.load_from_json(file_name)
 
-    def add_token(self, t, i = None):
-        if t in self.t2i: return
-        if i is None: i = len(self.t2i)
+    def add_token(self, t, i=None):
+        if t in self.t2i:
+            return
+        if i is None:
+            i = len(self.t2i)
         (self.t2i[t], self.i2t[i]) = (i, t)
-        self.vs = len(self.t2i) # equal to len(self.i2t) as well
+        self.vs = len(self.t2i)  # equal to len(self.i2t) as well
         return i
 
-    def get_token_i(self, t, *, add_if_unknown = False): return self.add_token(t) if add_if_unknown else self.t2i.get(t, 0)
+    def get_token_i(self, t, *, add_if_unknown=False):
+        return self.add_token(t) if add_if_unknown else self.t2i.get(t, 0)
 
     def build_tokens_from_string(self, string):
-        for t in string: self.add_token(t)
+        for t in string:
+            self.add_token(t)
 
-    def tokenize(self, s, *, add_if_unknown = False):
-        token_ids = [self.get_token_i(token, add_if_unknown=add_if_unknown) for token in s] # list of t tokens
-        return torch.tensor(token_ids)[None,:] # [1, t]
+    def tokenize(self, s, *, add_if_unknown=False):
+        token_ids = [
+            self.get_token_i(token, add_if_unknown=add_if_unknown) for token in s
+        ]  # list of t tokens
+        return torch.tensor(token_ids)[None, :]  # [1, t]
 
     def detokenize(self, tokens, *, join=True):
-        if len(tokens.shape) > 1: tokens = tokens.view(-1) # [b, t] -> [b * t]
-        token_chars = [self.i2t.get(i, f'[{i}]?') for i in tokens.tolist()]
-        return ''.join(token_chars) if join else token_chars
+        if len(tokens.shape) > 1:
+            tokens = tokens.view(-1)  # [b, t] -> [b * t]
+        token_chars = [self.i2t.get(i, f"[{i}]?") for i in tokens.tolist()]
+        return "".join(token_chars) if join else token_chars
 
-    def save_to_json(self, file_name): save_json(dict(t2i = self.t2i), file_name)
+    def save_to_json(self, file_name):
+        save_json(dict(t2i=self.t2i), file_name)
 
     def load_from_json(self, file_name):
-        if 't2i' in (obj := load_json(file_name)):
-            for (k, v) in obj['t2i'].items(): self.add_token(k, int(v))
-        else: log(f"Could not load from {file_name=}: invalid {obj=}")
+        if "t2i" in (obj := load_json(file_name)):
+            for k, v in obj["t2i"].items():
+                self.add_token(k, int(v))
+        else:
+            log(f"Could not load from {file_name=}: invalid {obj=}")
+
 
 class HfTokenizer(Tokenizer):
-    """ A base class for the HF tokenizers (gpt2, autotokenizer) """
-    def __init__(self, *, m_name=None, m_path=None, st_index=None, et_index=None): # start token index, end token index
-        (self.hf_tokenizer, self.m_name) = (load_pretrained_hf_tokenizer(m_name=m_name, m_path=m_path), m_name)
-        self.vs = self.hf_tokenizer.vocab_size #
-        if(self.m_name is None):
-            self.m_name=''
+    """A base class for the HF tokenizers (gpt2, autotokenizer)"""
 
-        (self.st_index, self.et_index) = (None, None) # start and end token indices (may need to be hacked)
+    def __init__(
+        self, *, m_name=None, m_path=None, st_index=None, et_index=None
+    ):  # start token index, end token index
+        (self.hf_tokenizer, self.m_name) = (
+            load_pretrained_hf_tokenizer(m_name=m_name, m_path=m_path),
+            m_name,
+        )
+        self.vs = self.hf_tokenizer.vocab_size  #
+        if self.m_name is None:
+            self.m_name = ""
+
+        (self.st_index, self.et_index) = (
+            None,
+            None,
+        )  # start and end token indices (may need to be hacked)
 
     def tokenize(self, s, **params):
-        if self.m_name.startswith('gpt2'): s = sanitize_quotes(s) # {?} a bit hacky
-        return self.hf_tokenizer(s, return_tensors='pt', verbose=True).input_ids # [1, t]
+        if self.m_name.startswith("gpt2"):
+            s = sanitize_quotes(s)  # {?} a bit hacky
+        return self.hf_tokenizer(
+            s, return_tensors="pt", verbose=True
+        ).input_ids  # [1, t]
 
     def detokenize(self, tokens, *, join=True):
-        tokens = tokens.to(dtype=torch.int64) # To convert other types in case
-        if len(tokens.shape) > 1: tokens = tokens.view(-1) # [b, t] -> [b * t]
+        tokens = tokens.to(dtype=torch.int64)  # To convert other types in case
+        if len(tokens.shape) > 1:
+            tokens = tokens.view(-1)  # [b, t] -> [b * t]
         t_strings = [self.hf_tokenizer.decode(tokens)]
 
-        return ''.join(t_strings) if join else t_strings
+        return "".join(t_strings) if join else t_strings
 
-def load_pretrained_hf_tokenizer(*, m_name:str=None, m_path:str=None):
+
+def load_pretrained_hf_tokenizer(*, m_name: str = None, m_path: str = None):
     """
     Loads a pre-trained Hugging Face tokenizer
 
@@ -173,9 +293,13 @@ def load_pretrained_hf_tokenizer(*, m_name:str=None, m_path:str=None):
             'bert-base-uncased') to be downloaded if necessary
         m_path: the file path to the tokenizer (if stored in a directory)
     """
-    if m_path is not None: return AutoTokenizer.from_pretrained(m_path,use_fast=True)
-    elif m_name is not None: return AutoTokenizer.from_pretrained(m_name,use_fast=True)
-    else: return None
+    if m_path is not None:
+        return AutoTokenizer.from_pretrained(m_path, use_fast=True)
+    elif m_name is not None:
+        return AutoTokenizer.from_pretrained(m_name, use_fast=True)
+    else:
+        return None
+
 
 tokenizers_by_name = {}
 
@@ -183,7 +307,10 @@ tokenizers_by_name = {}
 ### MAIN FUNCTIONS ###
 ######################
 
-def get_tokenizer(*, m_name:str=None, tokenizer_name:str=None, m_path:str=None):
+
+def get_tokenizer(
+    *, m_name: str = None, tokenizer_name: str = None, m_path: str = None
+):
     """
     Args:
         tokenizer_name (optional): if there is a tokenizer with that name in
@@ -193,10 +320,22 @@ def get_tokenizer(*, m_name:str=None, tokenizer_name:str=None, m_path:str=None):
         m_path (optional): the path to the (HuggingFace) tokenizer (saved
             offline)
     """
-    return HfTokenizer(m_name=m_name, m_path=m_path) if any_not_none(m_name, m_path) else tokenizers_by_name.get(tokenizer_name)
+    return (
+        HfTokenizer(m_name=m_name, m_path=m_path)
+        if any_not_none(m_name, m_path)
+        else tokenizers_by_name.get(tokenizer_name)
+    )
 
 
-def tokenize_txt_file(txt_file_path:str, pt_file_path:str, *, tokenizer_name:str=None, m_name:str=None, m_path:str=None, dtype:torch.dtype=None):
+def tokenize_txt_file(
+    txt_file_path: str,
+    pt_file_path: str,
+    *,
+    tokenizer_name: str = None,
+    m_name: str = None,
+    m_path: str = None,
+    dtype: torch.dtype = None,
+):
     """
     Converts a txt file into a pytorch file containing the ids of the tensors
     (in format [1, t] where t is the number of tokesn)
@@ -214,38 +353,64 @@ def tokenize_txt_file(txt_file_path:str, pt_file_path:str, *, tokenizer_name:str
             type (such as int16) can be specified
     """
     global tokenizers_by_name
-    tokenizer = get_tokenizer(tokenizer_name=tokenizer_name, m_name=m_name, m_path=m_path)
-    if tokenizer is None: return log("Could not build tokenizer")
+    tokenizer = get_tokenizer(
+        tokenizer_name=tokenizer_name, m_name=m_name, m_path=m_path
+    )
+    if tokenizer is None:
+        return log("Could not build tokenizer")
     tokenizer.tokenize_txt_file_to_pt_file(txt_file_path, pt_file_path, dtype=dtype)
 
-def tokenize_dir_txt_files_from_tok(dir_path: str, pt_file_path: str, *, tokenizer : HfTokenizer=None, dtype:torch.dtype=None):
-    if pt_file_path.endswith('.pt'): pt_file_path = pt_file_path[:-len('.pt')]
-    if pt_file_path.endswith('.txt'): pt_file_path = pt_file_path[:-len('.txt')]
+
+def tokenize_dir_txt_files_from_tok(
+    dir_path: str,
+    pt_file_path: str,
+    *,
+    tokenizer: HfTokenizer = None,
+    dtype: torch.dtype = None,
+):
+    if pt_file_path.endswith(".pt"):
+        pt_file_path = pt_file_path[: -len(".pt")]
+    if pt_file_path.endswith(".txt"):
+        pt_file_path = pt_file_path[: -len(".txt")]
 
     txt_file_paths = []
-    for (subdir, _, files) in os.walk(dir_path):
-        txt_file_paths.extend([os.path.join(subdir, file) for file in files if file.endswith('.txt')])
+    for subdir, _, files in os.walk(dir_path):
+        txt_file_paths.extend(
+            [os.path.join(subdir, file) for file in files if file.endswith(".txt")]
+        )
 
     part_index = 0
-    big_txt = '' # A concatenation of the files
+    big_txt = ""  # A concatenation of the files
 
     def save_and_clear_big_txt(big_txt, part_index):
-        part_txt_file_path = pt_file_path + f'_{part_index:04}_bigtext.txt'
+        part_txt_file_path = pt_file_path + f"_{part_index:04}_bigtext.txt"
         save_string(big_txt, part_txt_file_path)
-        part_pt_file_path = pt_file_path + f'_{part_index:04}.pt'
-        tokenizer.tokenize_txt_file_to_pt_file(part_txt_file_path, part_pt_file_path, dtype=dtype)
+        part_pt_file_path = pt_file_path + f"_{part_index:04}.pt"
+        tokenizer.tokenize_txt_file_to_pt_file(
+            part_txt_file_path, part_pt_file_path, dtype=dtype
+        )
         os.remove(part_txt_file_path)
         log(f"Saved and cleared part {part_index:04}")
 
     print("Starting tokenization of files")
     for txt_file_path in tqdm(txt_file_paths):
         print(f"Adding {txt_file_path} to big_txt")
-        txt = load_string(txt_file_path) + ('\n' * 5)
+        txt = load_string(txt_file_path) + ("\n" * 5)
         big_txt += txt
 
     save_and_clear_big_txt(big_txt, part_index)
 
-def tokenize_dir_txt_files(dir_path: str, pt_file_path: str, *, tokenizer_name:str=None, m_name:str=None, m_path:str=None, dtype:torch.dtype=None, limit_size=500*1024*1024):
+
+def tokenize_dir_txt_files(
+    dir_path: str,
+    pt_file_path: str,
+    *,
+    tokenizer_name: str = None,
+    m_name: str = None,
+    m_path: str = None,
+    dtype: torch.dtype = None,
+    limit_size=500 * 1024 * 1024,
+):
     """
     Converts all the txt files into a pytorch file containing the ids of the
     tensors (in format [1, t] where t is the number of tokesn)
@@ -262,8 +427,12 @@ def tokenize_dir_txt_files(dir_path: str, pt_file_path: str, *, tokenizer_name:s
         dtype (optional): by default, the token tensors are int64, but another
             type (such as int16) can be specified
     """
-    tokenizer = get_tokenizer(tokenizer_name=tokenizer_name, m_name=m_name, m_path=m_path)
-    tokenize_dir_txt_files_from_tok(dir_path, pt_file_path, tokenizer=tokenizer, dtype=dtype)
+    tokenizer = get_tokenizer(
+        tokenizer_name=tokenizer_name, m_name=m_name, m_path=m_path
+    )
+    tokenize_dir_txt_files_from_tok(
+        dir_path, pt_file_path, tokenizer=tokenizer, dtype=dtype
+    )
 
     # if pt_file_path.endswith('.pt'): pt_file_path = pt_file_path[:-len('.pt')]
     # if pt_file_path.endswith('.txt'): pt_file_path = pt_file_path[:-len('.txt')]
@@ -299,8 +468,8 @@ def tokenize_dir_txt_files(dir_path: str, pt_file_path: str, *, tokenizer_name:s
     #     print(f"Full big_txt length : {len(big_txt)}")
     # save_and_clear_big_txt(big_txt, part_index)
 
-if __name__ == "__main__":
 
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="""
         Tokenize .txt files in a given directory into PyTorch tensors of the
@@ -316,19 +485,21 @@ if __name__ == "__main__":
         type=str,
         help="""
         The directory path containing the txt files.
-        """
+        """,
     )
+
+    # TODO: merge both into one arg as AutoTokenizer works for either
 
     toks = parser.add_mutually_exclusive_group()
 
     toks.add_argument(
         "--tokenizer",
         type=str,
-        default='gpt2',
+        default="gpt2",
         help="""
         The name of the Huggingface-downloadable tokenizer to
         use. Default: 'gpt2'.
-        """
+        """,
     )
 
     toks.add_argument(
@@ -337,28 +508,30 @@ if __name__ == "__main__":
         default=None,
         help="""
         The name of the locally saved tokenizer to use.
-        """
+        """,
     )
 
     parser.add_argument(
         "--dtype",
         type=str,
-        choices=["uint8","visuint16","int32","int64"],
+        choices=["uint8", "visuint16", "int32", "int64"],
         default=None,
         help="""
         The dtype to cast the PyTorch tensors into. Choices:
         'uint8,visuint16,int32,int64'. Default: None.
-        """
+        """,
     )
 
     args = parser.parse_args()
 
-    print(f"Received: dir: {args.input_directory}, model:{args.tokenizer}, dtype :{args.dtype}")
+    print(
+        f"Received: dir: {args.input_directory}, model:{args.tokenizer}, dtype :{args.dtype}"
+    )
 
     tokenize_dir_txt_files(
-        dir_path = args.input_directory,
-        pt_file_path = f"{args.input_directory}.pt",
+        dir_path=args.input_directory,
+        pt_file_path=f"{args.input_directory}.pt",
         m_name=args.tokenizer,
         m_path=args.tokenizer_local,
-        dtype=args.dtype
+        dtype=args.dtype,
     )

--- a/modules/tokenizer.py
+++ b/modules/tokenizer.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import sys
 import json
 import pathlib
 import argparse

--- a/tokenize_to_h5.py
+++ b/tokenize_to_h5.py
@@ -34,14 +34,20 @@ def txt_to_h5(txt_path, out_h5_folder, tokenizer_folder, tokenizer_name):
         tokenizer_folder (str): Folder where the tokenizer will be saved
         tokenizer_name (str): Name of the tokenizer that will be saved
     """
-    create_tokenizer(txt_path, tokenizer_folder,tokenizer_name=tokenizer_name)
-    tokenize_folder(os.path.dirname(txt_path), os.path.join(tokenizer_folder,tokenizer_name))
-    toki = get_tokenizer(m_path=os.path.join(tokenizer_folder,tokenizer_name))
-    make_h5(os.path.dirname(txt_path), os.path.splitext(os.path.basename(txt_path))[0], out_h5_folder,toki)
+    create_tokenizer(txt_path, tokenizer_folder, tokenizer_name=tokenizer_name)
+    tokenize_folder(
+        os.path.dirname(txt_path), os.path.join(tokenizer_folder, tokenizer_name)
+    )
+    toki = get_tokenizer(m_path=os.path.join(tokenizer_folder, tokenizer_name))
+    make_h5(
+        os.path.dirname(txt_path),
+        os.path.splitext(os.path.basename(txt_path))[0],
+        out_h5_folder,
+        toki,
+    )
 
 
-if __name__=='__main__':
-
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="""
         Script for preparing a .txt cc-100 dataset for training. Creates the
@@ -76,9 +82,10 @@ if __name__=='__main__':
 
     txt_folder = os.path.split(args.txt_path)[0]
 
-    out_h5_folder = f"{txt_folder}_h5" #  Folder that will contain the output .h5 file
-    tokenizer_folder = "modules/tokenizers" # Folder where the tokenizer will be saved
-    tokenizer_name = f"{txt_folder}_tokenizer" # Name of the tokenizer that will be saved
+    out_h5_folder = f"{txt_folder}_h5"  #  Folder that will contain the output .h5 file
+    tokenizer_folder = "modules/tokenizers"  # Folder where the tokenizer will be saved
+    # Name of the tokenizer that will be saved
+    tokenizer_name = f"{txt_folder}_tokenizer"
 
     ################## DO NOT MODIFY BELOW ##################
     txt_to_h5(args.txt_path, out_h5_folder, tokenizer_folder, tokenizer_name)

--- a/train.py
+++ b/train.py
@@ -21,8 +21,14 @@ from modules import get_tokenizer
 from torchenhanced import CosineWarmup
 
 
-def train(model_name : str, file_location : str, device : str | list[str], tokenizer_path : str ,
-           project_name :str, step_pickup: bool=True):
+def train(
+    model_name: str,
+    file_location: str,
+    device: str | list[str],
+    tokenizer_path: str,
+    project_name: str,
+    step_pickup: bool = True,
+):
     """
     Main train script. Launches training of a model given parameters in a JSON file at file_location
 
@@ -40,124 +46,181 @@ def train(model_name : str, file_location : str, device : str | list[str], token
     cur_path = pathlib.Path(__file__).parent.absolute().as_posix()
     run_name = os.path.splitext(os.path.basename(file_location))[0]
 
-    print('TOKENIZER PATH : ', os.path.join(cur_path,tokenizer_path))
-    if(tokenizer_path is None):
-        raise(ValueError('Tokenizer path required, please specify with -t <tokenizer_path>'))
-    if(not os.path.exists(os.path.join(cur_path,tokenizer_path))):
-        raise(FileNotFoundError(f'Tokenizer not found at path {os.path.join(cur_path,tokenizer_path)}. \n \
-                                Tokenizer path should be relative to train_script.py.'))
+    print("TOKENIZER PATH : ", os.path.join(cur_path, tokenizer_path))
+    if tokenizer_path is None:
+        raise (
+            ValueError(
+                "Tokenizer path required, please specify with -t <tokenizer_path>"
+            )
+        )
+    if not os.path.exists(os.path.join(cur_path, tokenizer_path)):
+        raise (
+            FileNotFoundError(f"Tokenizer not found at path {os.path.join(cur_path,tokenizer_path)}. \n \
+                                Tokenizer path should be relative to train_script.py.")
+        )
 
-    tokenizer_path = os.path.join(cur_path,tokenizer_path)
+    tokenizer_path = os.path.join(cur_path, tokenizer_path)
     tokenizer = get_tokenizer(m_path=tokenizer_path)
 
     try:
-        with open(file_location,'r') as f :
+        with open(file_location, "r") as f:
             configo = json.load(f)
-            model_params = configo['model_params']
-            training_params = configo['training_params']
-            optim_params = configo['optim_params']
+            model_params = configo["model_params"]
+            training_params = configo["training_params"]
+            optim_params = configo["optim_params"]
     except Exception as e:
-        print('Error reading JSON file !')
-        raise(e)
+        print("Error reading JSON file !")
+        raise (e)
 
-    if not os.path.exists(training_params['dataset_folder']):
+    if not os.path.exists(training_params["dataset_folder"]):
         raise FileNotFoundError(f"Tried to find dataset folder at \
                                 {training_params['dataset_folder']}, but failed. \
                                 Make sure there is the folder {training_params['dataset_folder']}\
                                 in the same directory.")
 
-    if(isinstance(device, (list, tuple))):
-        parallel=list(device)
-        device=parallel[0]
+    if isinstance(device, (list, tuple)):
+        parallel = list(device)
+        device = parallel[0]
     else:
-        parallel=None
+        parallel = None
 
+    # We ask how many validation steps. To get these, we assume 5% of training
+    # time allocated for validation.
+    valid_steps = training_params["valid_steps"]
+    valid_percent_time = 5  # Time spent validating, in percentage
+    valid_percent_time = valid_percent_time / 100
 
-    valid_steps =training_params['valid_steps'] # We ask how many validation steps. To get these, we assume 5% of training time allocated for validation.
-    valid_percent_time=5 # Time spent validating, in percentage
-    valid_percent_time=valid_percent_time/100
+    valid_every = int(valid_steps / valid_percent_time)
 
-    valid_every = int(valid_steps/valid_percent_time)
+    backwards = training_params["backwards"]  # If we train backwards
 
-    backwards = training_params['backwards'] # If we train backwards
-
-    rng = np.random.default_rng(42) # For deterministic shuffling of dataset
+    rng = np.random.default_rng(42)  # For deterministic shuffling of dataset
 
     # First copy the dataset in the current folder.
     # This is useful in the case of a network drive, where the dataset is slow to access.
     # Can be removed if dataset location is local.
 
-    dataset_path = training_params['dataset_folder']
-    destination_path = os.path.join(cur_path,'local_dataset.h5')
+    dataset_path = training_params["dataset_folder"]
+    destination_path = os.path.join(cur_path, "local_dataset.h5")
 
-    if(not os.path.exists(destination_path)):
-        print('Copying dataset to current folder...')
+    if not os.path.exists(destination_path):
+        print("Copying dataset to current folder...")
         shutil.copy(dataset_path, destination_path)
-    else :
-        print('Dataset already copied to current folder, using this one.')
+    else:
+        print("Dataset already copied to current folder, using this one.")
 
     # Generate and shuffle the dataset
-    motherDataset = TokenTextBOS(h5_file=destination_path, attn_length=model_params['attn_length'], backwards=backwards)
+    motherDataset = TokenTextBOS(
+        h5_file=destination_path,
+        attn_length=model_params["attn_length"],
+        backwards=backwards,
+    )
     indices = np.arange(len(motherDataset))
     rng.shuffle(indices)
-    motherDataset = Subset(motherDataset, list(indices)) # Shuffled dataset
+    motherDataset = Subset(motherDataset, list(indices))  # Shuffled dataset
 
     # To keep it constant even if we switch batch_size, I take 250*valid_steps datapoints in the validation set
-    val_inds = valid_steps*250
-    val_range = range(len(motherDataset)-val_inds,len(motherDataset)) # Validation, last portion of dataset
-    keep_range = range(len(motherDataset)-val_inds) # Training, first portion of dataset
+    val_inds = valid_steps * 250
+    # Validation, last portion of dataset
+    val_range = range(len(motherDataset) - val_inds, len(motherDataset))
+    # Training, first portion of dataset
+    keep_range = range(len(motherDataset) - val_inds)
 
     del indices
 
-    #Whether backwards or forwards, its the individual examples that are flipped, not the dataset. So same thing for both !
+    # Whether backwards or forwards, its the individual examples that are flipped, not the dataset. So same thing for both !
     train_dataset = Subset(motherDataset, keep_range)
     val_dataset = Subset(motherDataset, val_range)
 
-    print('Datapoint example. Check it looks correct ! : ')
-    print('TRAIN DATA   :',tokenizer.detokenize(train_dataset[0][0][:20]))
-    print('TRAIN ANSWER : ',tokenizer.detokenize(train_dataset[0][1][:20]))
-    print('VALID DATA   :',tokenizer.detokenize(val_dataset[0][0][:20]))
-    print('VALID ANSWER : ',tokenizer.detokenize(val_dataset[0][1][:20]))
+    print("Datapoint example. Check it looks correct ! : ")
+    print("TRAIN DATA   :", tokenizer.detokenize(train_dataset[0][0][:20]))
+    print("TRAIN ANSWER : ", tokenizer.detokenize(train_dataset[0][1][:20]))
+    print("VALID DATA   :", tokenizer.detokenize(val_dataset[0][0][:20]))
+    print("VALID ANSWER : ", tokenizer.detokenize(val_dataset[0][1][:20]))
 
     model = load_model(model_name, model_params)
 
-    #====================== TRAINING PARAMETERS =======================
-    batch_size = training_params['batch_size']
-    aggregate = training_params['aggregate']
-    totbatches = len(train_dataset)//batch_size
+    # ====================== TRAINING PARAMETERS =======================
+    batch_size = training_params["batch_size"]
+    aggregate = training_params["aggregate"]
+    totbatches = len(train_dataset) // batch_size
 
-    if(training_params['steps_to_train'] is None):
-        steps_to_train = totbatches*4
+    if training_params["steps_to_train"] is None:
+        steps_to_train = totbatches * 4
     else:
-        steps_to_train = training_params['steps_to_train']
+        steps_to_train = training_params["steps_to_train"]
 
-    print(f'{totbatches=}, {batch_size=}, {len(train_dataset)=}')
-    base_lr = optim_params['lr']
-    warmup_steps = optim_params['warmup_steps']
-    oscil_steps = optim_params['oscil_steps'] # Period of cosine restart for oscillation
-    lr_shrink_factor=optim_params['lr_shrink']
-    lr_min = optim_params['lr_min']
-    lr_init = optim_params['lr_init']
+    print(f"{totbatches=}, {batch_size=}, {len(train_dataset)=}")
+    base_lr = optim_params["lr"]
+    warmup_steps = optim_params["warmup_steps"]
+    oscil_steps = optim_params[
+        "oscil_steps"
+    ]  # Period of cosine restart for oscillation
+    lr_shrink_factor = optim_params["lr_shrink"]
+    lr_min = optim_params["lr_min"]
+    lr_init = optim_params["lr_init"]
 
-    print(f'--- Training for ~ {steps_to_train//1000}k minibatches ---')
-    #------ Optimizers ------
+    print(f"--- Training for ~ {steps_to_train//1000}k minibatches ---")
+    # ------ Optimizers ------
     optim = torch.optim.AdamW(model.parameters(), lr=base_lr)
     # Cosine schedule with Warmup, from torchenhanced package
-    scheduler = CosineWarmup(optim,warmup_steps=warmup_steps,lr_shrink=lr_shrink_factor,
-                             lr_init=lr_init,T_0=oscil_steps,eta_min=lr_min)
+    scheduler = CosineWarmup(
+        optim,
+        warmup_steps=warmup_steps,
+        lr_shrink=lr_shrink_factor,
+        lr_init=lr_init,
+        T_0=oscil_steps,
+        eta_min=lr_min,
+    )
 
     # Intialize the trainer class
-    trainer_config = dict(model=model,optim=optim,scheduler=scheduler,
-        train_dataset=train_dataset,valid_dataset=val_dataset, detokenizer=tokenizer,
-        run_name=run_name, project_name=project_name, state_save_loc=training_params['state_save_loc'], backwards=backwards,
-        device=device, parallel=parallel, run_config={'model_params':model_params,'train':training_params,'opti':optim_params} )
+    trainer_config = dict(
+        model=model,
+        optim=optim,
+        scheduler=scheduler,
+        train_dataset=train_dataset,
+        valid_dataset=val_dataset,
+        detokenizer=tokenizer,
+        run_name=run_name,
+        project_name=project_name,
+        state_save_loc=training_params["state_save_loc"],
+        backwards=backwards,
+        device=device,
+        parallel=parallel,
+        run_config={
+            "model_params": model_params,
+            "train": training_params,
+            "opti": optim_params,
+        },
+    )
 
     trainer = load_trainer(model_name, trainer_config=trainer_config)
 
-
-    if(os.path.exists(os.path.join(training_params['state_save_loc'],project_name,'state',run_name+'.state'))):
-        trainer.load_state(os.path.join(training_params['state_save_loc'],project_name,'state',run_name+'.state'))
-    trainer.stepnum =1
-    trainer.train_steps(steps=steps_to_train,save_every=2000,aggregate=aggregate,
-                        backup_every=training_params['backup_every'],step_log=training_params['step_log'],
-                        batch_size=batch_size,valid_every=valid_every,resume_batches=True,pickup=step_pickup)
+    if os.path.exists(
+        os.path.join(
+            training_params["state_save_loc"],
+            project_name,
+            "state",
+            run_name + ".state",
+        )
+    ):
+        trainer.load_state(
+            os.path.join(
+                training_params["state_save_loc"],
+                project_name,
+                "state",
+                run_name + ".state",
+            )
+        )
+    trainer.stepnum = 1
+    trainer.train_steps(
+        steps=steps_to_train,
+        save_every=2000,
+        aggregate=aggregate,
+        backup_every=training_params["backup_every"],
+        step_log=training_params["step_log"],
+        batch_size=batch_size,
+        valid_every=valid_every,
+        resume_batches=True,
+        pickup=step_pickup,
+    )

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -49,6 +49,7 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--project_name", "-p",
+        default="CodePerplexity",
         help="""
         Name of the project to log to. Default is 'CodePerplexity'
         """,
@@ -65,16 +66,11 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    if args.project_name is None:
-        project_name = "CodePerplexity"
-    else:
-        project_name = args.project_name
-
     train(
         model_name="gpt",
         file_location=args.file_location,
         device=args.device,
         tokenizer_path=args.tokenizer_path,
-        project_name=project_name,
+        project_name=args.project_name,
         step_pickup=args.no_step_pickup,
     )

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -16,20 +16,65 @@ import argparse
 from train import train
 
 
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Starts training of Predictor model given a JSON config file."
+    )
 
-if __name__=='__main__':
-    parser = argparse.ArgumentParser(description="Starts training of Predictor model given a JSON config file.")
-    parser.add_argument("file_location", help="Path to the JSON config file. Relative to where you launch the script from.")
-    parser.add_argument("-d", "--device", type=str, default='cpu', help="Device string, e.g. 'cuda:0' or 'cpu'")
-    parser.add_argument("-t", "--tokenizer_path", type=str,help="Path for the tokenizer to use (only used for logging snippets). Relative to the train_script folder.")
-    parser.add_argument("-p", "--project_name", help="Name of the project to log to. Default is 'BackPerplexityResilient'")
-    parser.add_argument("-s", "--no_step_pickup", action="store_false", help="If set, train steps_to_train steps more. Otherwise, will train UP TO steps_to_train TOTAL steps.")
+    parser.add_argument(
+        "file_location",
+        help="""
+        Path to the JSON config file. Relative to where you launch the script
+        from.
+        """,
+    )
+
+    parser.add_argument(
+        "--device", "-d",
+        type=str,
+        default="cpu",
+        help="""
+        Device string, e.g. 'cuda:0' or 'cpu'
+        """,
+    )
+
+    parser.add_argument(
+        "--tokenizer_path", "-t",
+        type=str,
+        help="""
+        Path for the tokenizer to use (only used for logging snippets).
+        Relative to the train_script folder.
+        """,
+    )
+
+    parser.add_argument(
+        "--project_name", "-p",
+        help="""
+        Name of the project to log to. Default is 'CodePerplexity'
+        """,
+    )
+
+    parser.add_argument(
+        "--no_step_pickup", "-s",
+        action="store_false",
+        help="""
+        If set, train steps_to_train steps more. Otherwise, will train UP TO
+        steps_to_train TOTAL steps.
+        """,
+    )
+
     args = parser.parse_args()
 
-    if(args.project_name is None):
-        project_name = 'CodePerplexity'
+    if args.project_name is None:
+        project_name = "CodePerplexity"
     else:
         project_name = args.project_name
 
-    train(model_name='gpt',file_location=args.file_location, device=args.device, tokenizer_path=args.tokenizer_path,
-          project_name=project_name, step_pickup=args.no_step_pickup)
+    train(
+        model_name="gpt",
+        file_location=args.file_location,
+        device=args.device,
+        tokenizer_path=args.tokenizer_path,
+        project_name=project_name,
+        step_pickup=args.no_step_pickup,
+    )

--- a/train_gru.py
+++ b/train_gru.py
@@ -15,19 +15,63 @@ import argparse
 
 from train import train
 
-if __name__=='__main__':
-    parser = argparse.ArgumentParser(description="Starts training of Predictor model given a JSON config file.")
-    parser.add_argument("file_location", help="Path to the JSON config file. Relative to where you launch the script from.")
-    parser.add_argument("-d", "--device", type=str, default='cpu', help="Device string, e.g. 'cuda:0' or 'cpu'")
-    parser.add_argument("-t", "--tokenizer_path", type=str,help="Path for the tokenizer to use (only used for logging snippets). Relative to the train_script folder.")
-    parser.add_argument("-p", "--project_name", help="Name of the project to log to. Default is 'CodePerplexity'")
-    parser.add_argument("-s", "--no_step_pickup", action="store_false", help="If set, train steps_to_train steps more. Otherwise, will train UP TO steps_to_train TOTAL steps.")
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="""
+        Starts training of Predictor model given a JSON config file.
+        """
+    )
+
+    parser.add_argument(
+        "file_location",
+        help="""
+        Path to the JSON config file. Relative to where you launch the script
+        from.
+        """,
+    )
+
+    parser.add_argument(
+        "--device", "-d",
+        type=str,
+        default="cpu",
+        help="""
+        Device string, e.g. 'cuda:0' or 'cpu'
+        """,
+    )
+
+    parser.add_argument(
+        "--tokenizer_path", "-t",
+        type=str,
+        help="""
+        Path for the tokenizer to use (only used for logging snippets).
+        Relative to the train_script folder.
+        """,
+    )
+
+    parser.add_argument(
+        "--project_name", "-p",
+        default="CodePerplexity",
+        help="""
+        Name of the project to log to. Default is 'CodePerplexity'
+        """,
+    )
+
+    parser.add_argument(
+        "--no_step_pickup", "-s",
+        action="store_false",
+        help="""
+        If set, train steps_to_train steps more. Otherwise, will train UP TO
+        steps_to_train TOTAL steps.
+        """,
+    )
+
     args = parser.parse_args()
 
-    if(args.project_name is None):
-        project_name = 'CodePerplexity'
-    else:
-        project_name = args.project_name
-
-    train(model_name='gru', file_location=args.file_location, device=args.device, tokenizer_path=args.tokenizer_path,
-          project_name=project_name, step_pickup=args.no_step_pickup)
+    train(
+        model_name="gru",
+        file_location=args.file_location,
+        device=args.device,
+        tokenizer_path=args.tokenizer_path,
+        project_name=args.project_name,
+        step_pickup=args.no_step_pickup,
+    )

--- a/train_lstm.py
+++ b/train_lstm.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--project_name", "-p",
-        default="CodePerplexity"
+        default="CodePerplexity",
         help="""
         Name of the project to log to. Default is 'CodePerplexity'
         """,

--- a/train_lstm.py
+++ b/train_lstm.py
@@ -16,19 +16,61 @@ import argparse
 
 from train import train
 
-if __name__=='__main__':
-    parser = argparse.ArgumentParser(description="Starts training of Predictor model given a JSON config file.")
-    parser.add_argument("file_location", help="Path to the JSON config file. Relative to where you launch the script from.")
-    parser.add_argument("-d", "--device", type=str, default='cpu', help="Device string, e.g. 'cuda:0' or 'cpu'")
-    parser.add_argument("-t", "--tokenizer_path", type=str,help="Path for the tokenizer to use (only used for logging snippets). Relative to the train_script folder.")
-    parser.add_argument("-p", "--project_name", help="Name of the project to log to. Default is 'CodePerplexity'")
-    parser.add_argument("-s", "--no_step_pickup", action="store_false", help="If set, train steps_to_train steps more. Otherwise, will train UP TO steps_to_train TOTAL steps.")
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Starts training of Predictor model given a JSON config file."
+    )
+
+    parser.add_argument(
+        "file_location",
+        help="""
+        Path to the JSON config file. Relative to where you launch the script
+        from.
+        """,
+    )
+
+    parser.add_argument(
+        "--device", "-d",
+        type=str,
+        default="cpu",
+        help="""
+        Device string, e.g. 'cuda:0' or 'cpu'
+        """,
+    )
+
+    parser.add_argument(
+        "--tokenizer_path", "-t",
+        type=str,
+        help="""
+        Path for the tokenizer to use (only used for logging snippets).
+        Relative to the train_script folder.
+        """,
+    )
+
+    parser.add_argument(
+        "--project_name", "-p",
+        default="CodePerplexity"
+        help="""
+        Name of the project to log to. Default is 'CodePerplexity'
+        """,
+    )
+
+    parser.add_argument(
+        "--no_step_pickup", "-s",
+        action="store_false",
+        help="""
+        If set, train steps_to_train steps more. Otherwise, will train UP TO
+        steps_to_train TOTAL steps.
+        """,
+    )
+
     args = parser.parse_args()
 
-    if(args.project_name is None):
-        project_name = 'CodePerplexity'
-    else:
-        project_name = args.project_name
-
-    train(model_name='lstm', file_location=args.file_location, device=args.device, tokenizer_path=args.tokenizer_path,
-          project_name=project_name, step_pickup=args.no_step_pickup)
+    train(
+        model_name="lstm",
+        file_location=args.file_location,
+        device=args.device,
+        tokenizer_path=args.tokenizer_path,
+        project_name=args.project_name,
+        step_pickup=args.no_step_pickup,
+    )

--- a/train_parallel.py
+++ b/train_parallel.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--project_name", "-p",
-        default="CodePerplexity"
+        default="CodePerplexity",
         help="""
         Name of the project to log to. Default is 'CodePerplexity'
         """,

--- a/train_parallel.py
+++ b/train_parallel.py
@@ -17,19 +17,62 @@ import argparse
 from train import train
 
 
-if __name__=='__main__':
-    parser = argparse.ArgumentParser(description="Starts training of Predictor model given a JSON config file.")
-    parser.add_argument("file_location", help="Path to the JSON config file. Relative to where you launch the script from.")
-    parser.add_argument('-d','--devices', nargs='+', help='A list of devices')
-    parser.add_argument("-t", "--tokenizer_path", type=str,help="Path for the tokenizer to use (only used for logging snippets). Relative to the train_script folder.")
-    parser.add_argument("-p", "--project_name", help="Name of the project to log to. Default is 'BackPerplexityResilient'")
-    parser.add_argument("-s", "--no_step_pickup", action="store_false", help="If set, train steps_to_train steps more. Otherwise, will train UP TO steps_to_train TOTAL steps.")
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="""
+        Starts training of Predictor model given a JSON config file.
+        """
+    )
+
+    parser.add_argument(
+        "file_location",
+        help="""
+        Path to the JSON config file. Relative to where you launch the script
+        from.
+        """,
+    )
+
+    parser.add_argument(
+        "--devices", "-d",
+        nargs="+",
+        help="""
+        A list of devices
+        """,
+    )
+
+    parser.add_argument(
+        "--tokenizer_path", "-t",
+        type=str,
+        help="""
+        Path for the tokenizer to use (only used for logging snippets).
+        Relative to the train_script folder.
+        """,
+    )
+
+    parser.add_argument(
+        "--project_name", "-p",
+        default="CodePerplexity"
+        help="""
+        Name of the project to log to. Default is 'CodePerplexity'
+        """,
+    )
+
+    parser.add_argument(
+        "--no_step_pickup", "-s",
+        action="store_false",
+        help="""
+        If set, train steps_to_train steps more. Otherwise, will train UP TO
+        steps_to_train TOTAL steps.
+        """,
+    )
+
     args = parser.parse_args()
 
-    if(args.project_name is None):
-        project_name = 'CodePerplexity'
-    else:
-        project_name = args.project_name
-
-    train(model_name='gpt',file_location=args.file_location, device=args.device, tokenizer_path=args.tokenizer_path,
-          project_name=project_name, step_pickup=args.no_step_pickup)
+    train(
+        model_name="gpt",
+        file_location=args.file_location,
+        device=args.device,
+        tokenizer_path=args.tokenizer_path,
+        project_name=args.project_name,
+        step_pickup=args.no_step_pickup,
+    )


### PR DESCRIPTION
- Adding/improving argparse cli functionality to invert_text.py, modules/tokenizer.py, modules/tok_utils/create_custom_tokenizer.py & pt_to_h5.py
- Ruff formatting of the codebase (might be overkill, I'll let you judge: the formatter can also be added to VSCode, I think, nice bit of automation)
- Note on running `modules/tok_utils` scripts in Readme (to resolve the `from modules import...`, adding `path/to/modules` to the `PYTHONPATH` is required).
- Various Ruff fixes (unused variables & imports, some minor fixes)
